### PR TITLE
HOTFIX: Fixed some typos in the release notes what's new announcement.

### DIFF
--- a/_whatsnew/2025-10-06.adoc
+++ b/_whatsnew/2025-10-06.adoc
@@ -1,10 +1,10 @@
-=== NetApp Backup and Recovery is now NetApp Backup and Recovery
+=== BlueXP backup and recovery is now NetApp Backup and Recovery
  
-NetApp Backup and Recovery has been renamed to NetApp Backup and Recovery.
+BlueXP backup and recovery has been renamed to NetApp Backup and Recovery.
  
 === BlueXP is now NetApp Console
  
-The NetApp Console, built on the enhanced and restructured BlueXP foundation, provides centralized management of NetApp storage and NetApp Data Services across on-premises and cloud environments at enterprise grade—delivering real-time insights, faster workflows, and simplified administration, that is highly secure and compliant.
+The NetApp Console, built on the enhanced and restructured BlueXP foundation, provides centralized management of NetApp storage and NetApp Data Services across on-premises and cloud environments at enterprise grade—delivering real-time insights, faster workflows, and simplified administration that is highly secure and compliant.
  
 For details on what's changed, see the link:https://docs.netapp.com/us-en/console-relnotes/index.html[NetApp  Console release notes.]
 


### PR DESCRIPTION
This pull request updates the product naming in the release notes to reflect recent rebranding. The primary change is renaming "BlueXP backup and recovery" to "NetApp Backup and Recovery," and clarifying the relationship between BlueXP and the NetApp Console.

Product naming updates:

* Updated the release notes in `_whatsnew/2025-10-06.adoc` to state that "BlueXP backup and recovery" is now called "NetApp Backup and Recovery," correcting the previous redundant wording.
* Clarified the description of the NetApp Console, emphasizing its foundation on BlueXP and improving sentence clarity.