### PR TITLE
HOTFIX: Fixed B&R dashboard access steps.

### DIFF
--- a/br-start-discover-hyperv.adoc
+++ b/br-start-discover-hyperv.adoc
@@ -51,6 +51,7 @@ After NetApp Backup and Recovery discovers resources, the Inventory page display
 
 .Steps
 
-. To display the NetApp Backup and Recovery Dashboard, from the NetApp Console menu, select *Dashboard*.   
-
+. From the NetApp Console menu, select *Protection* > *Backup and recovery*.
+. Select a workload tile (for example, Microsoft SQL Server).
+. From the Backup and Recovery menu, select *Dashboard*.
 . Review the health of data protection. The number of at risk or protected workloads increases based on the newly discovered, protected, and backed up workloads.

--- a/br-start-discover-kubernetes.adoc
+++ b/br-start-discover-kubernetes.adoc
@@ -46,7 +46,9 @@ The cluster is added to the inventory.
 == Continue to the NetApp Backup and Recovery Dashboard
 Follow these steps to view the NetApp Backup and Recovery Dashboard. 
 
-. From the top menu, select *Dashboard*.   
+. From the NetApp Console menu, select *Protection* > *Backup and recovery*.
+. Select a workload tile (for example, Microsoft SQL Server).
+. From the Backup and Recovery menu, select *Dashboard*.
 
 . Review the health of data protection. The number of at risk or protected workloads increases based on the newly discovered, protected, and backed up workloads.  
 +

--- a/br-start-discover-kvm.adoc
+++ b/br-start-discover-kvm.adoc
@@ -51,6 +51,7 @@ The KVM workload is displayed in the list of workloads on the Inventory page.
 
 .Steps
 
-. To display the NetApp Backup and Recovery Dashboard, from the top menu, select *Dashboard*.   
-
+. From the NetApp Console menu, select *Protection* > *Backup and recovery*.
+. Select a workload tile (for example, Microsoft SQL Server).
+. From the Backup and Recovery menu, select *Dashboard*.
 . Review the health of data protection. The number of at risk or protected workloads increases based on the newly discovered, protected, and backed up workloads.

--- a/br-start-discover-oracle.adoc
+++ b/br-start-discover-oracle.adoc
@@ -97,8 +97,9 @@ The Oracle workload is displayed in the list of workloads on the Inventory page.
 == Continue to the NetApp Backup and Recovery Dashboard
 
 
-. To display the NetApp Backup and Recovery Dashboard, from the top menu, select *Dashboard*.   
-
+. From the NetApp Console menu, select *Protection* > *Backup and recovery*.
+. Select a workload tile (for example, Microsoft SQL Server).
+. From the Backup and Recovery menu, select *Dashboard*.
 . Review the health of data protection. The number of at risk or protected workloads increases based on the newly discovered, protected, and backed up workloads.  
 
 

--- a/br-start-discover.adoc
+++ b/br-start-discover.adoc
@@ -183,8 +183,9 @@ With Advanced Settings, you can manually install the plugin agent on all servers
 ==== Continue to the NetApp Backup and Recovery Dashboard
 
 
-. To display the NetApp Backup and Recovery Dashboard, from the Backup and Recovery menu, select *Dashboard*.   
-
+. From the NetApp Console menu, select *Protection* > *Backup and recovery*.
+. Select a workload tile (for example, Microsoft SQL Server).
+. From the Backup and Recovery menu, select *Dashboard*.
 . Review the health of data protection. The number of at risk or protected workloads increases based on the newly discovered, protected, and backed up workloads.  
 +
 link:br-use-dashboard.html[Learn what the Dashboard shows you].

--- a/br-use-dashboard.adoc
+++ b/br-use-dashboard.adoc
@@ -21,10 +21,12 @@ Storage viewer, Backup and Recovery super admin, Backup and Recovery backup admi
 
 .Steps
 
-. From the NetApp Backup and Recovery menu, select *Dashboard*.
-//+
-//image:screen-br-dashboard2.png[NetApp Backup and Recovery Dashboard]
-
+. From the NetApp Console menu, select *Protection* > *Backup and recovery*.
+. Select a workload tile (for example, Microsoft SQL Server).
+. From the Backup and Recovery menu, select *Dashboard*.
++
+You can review the following types of information:
++
 * Number of hosts or VMs discovered
 * Number of Kubernetes clusters discovered
 * Number of backup targets on object storage 


### PR DESCRIPTION
This pull request updates the instructions for accessing the NetApp Backup and Recovery Dashboard across multiple documentation files to provide a more consistent and detailed navigation path. The new steps guide users through the NetApp Console menu, selecting a workload tile, and then accessing the dashboard, replacing the previous, less specific instructions.

Navigation and documentation consistency improvements:

* Updated the procedure for accessing the NetApp Backup and Recovery Dashboard in multiple files (`br-start-discover.adoc`, `br-start-discover-hyperv.adoc`, `br-start-discover-kubernetes.adoc`, `br-start-discover-kvm.adoc`, `br-start-discover-oracle.adoc`, `br-use-dashboard.adoc`) to instruct users to select *Protection* > *Backup and recovery* from the NetApp Console menu, choose a workload tile, and then select *Dashboard* from the Backup and Recovery menu. [[1]](diffhunk://#diff-98d07fddd6075af1c9c3b5a70e6c401c4b7b6aab5a695fca31ef85a482e7b214L186-R188) [[2]](diffhunk://#diff-faca9cf84bd9d4a6185cd94ab339f7d0a6e2504f7c5c36fc5790362036700249L54-R56) [[3]](diffhunk://#diff-98a2a15d2d321ea44020bcfc45f673ac71a4b9b7706669beb2aca26e4fc64b09L49-R51) [[4]](diffhunk://#diff-fb8f66b897efa00253aaeed7a85602eb98d9ce4e22ba375a5c342b4dbfa034c7L54-R56) [[5]](diffhunk://#diff-cc329891cd5380eec7b81a102c860074040ae9c3aa6536b7d869658135650e4dL100-R102) [[6]](diffhunk://#diff-300b0320f2040e785c25271691d7fb631908d10b47441eccbc213b6772f2edd2L24-R29)

* Added clarifying details in the dashboard access steps, such as selecting a workload tile (e.g., Microsoft SQL Server), to provide clearer guidance for users. [[1]](diffhunk://#diff-98d07fddd6075af1c9c3b5a70e6c401c4b7b6aab5a695fca31ef85a482e7b214L186-R188) [[2]](diffhunk://#diff-faca9cf84bd9d4a6185cd94ab339f7d0a6e2504f7c5c36fc5790362036700249L54-R56) [[3]](diffhunk://#diff-98a2a15d2d321ea44020bcfc45f673ac71a4b9b7706669beb2aca26e4fc64b09L49-R51) [[4]](diffhunk://#diff-fb8f66b897efa00253aaeed7a85602eb98d9ce4e22ba375a5c342b4dbfa034c7L54-R56) [[5]](diffhunk://#diff-cc329891cd5380eec7b81a102c860074040ae9c3aa6536b7d869658135650e4dL100-R102) [[6]](diffhunk://#diff-300b0320f2040e785c25271691d7fb631908d10b47441eccbc213b6772f2edd2L24-R29)

* Enhanced the `br-use-dashboard.adoc` file to include a list of information types that can be reviewed from the Dashboard, improving user understanding of dashboard contents.