### PR TITLE
Hotfix to include mention of new DataLock support.

### DIFF
--- a/_whatsnew/2025-10-06.adoc
+++ b/_whatsnew/2025-10-06.adoc
@@ -77,3 +77,8 @@ This release of NetApp Backup and Recovery introduces support for discovering an
 * Oracle dashboard support
 
 For details about protecting Oracle Database workloads, refer to https://docs.netapp.com/us-en/data-services-backup-recovery/br-use-oracle-protect-overview.html[Protect Oracle workloads overview].
+
+=== ONTAP volume workload enhancements
+This release of ONTAP volume workloads introduces the following enhanced capability:
+
+Beginning with ONTAP 9.17.1 and newer, DataLock is now supported with Google Cloud Platform. This complements existing DataLock support with Amazon AWS, Microsoft Azure, and NetApp StorageGRID.


### PR DESCRIPTION
This pull request adds a new section to the release notes to announce enhancements for ONTAP volume workloads, specifically highlighting expanded DataLock support. The most important change is the announcement that DataLock is now supported with Google Cloud Platform for ONTAP 9.17.1 and newer, in addition to existing support for AWS, Azure, and StorageGRID.

ONTAP volume workload enhancements:

* Added a section announcing that DataLock is now supported with Google Cloud Platform for ONTAP 9.17.1 and newer, complementing existing support for AWS, Azure, and StorageGRID (`_whatsnew/2025-10-06.adoc`).