### PR TITLE
Hotfix: Hyper-V prereq fix.

### DIFF
--- a/concept-start-prereq.adoc
+++ b/concept-start-prereq.adoc
@@ -193,7 +193,6 @@ Ensure your Hyper-V instance meets specific requirements to discover and protect
 ** Microsoft Hyper-V 2019, 2022 & 2025 editions
 ** ASP.NET Core Runtime 8.0.12 Hosting Bundle (and all subsequent 8.0.x patches)
 ** PowerShell 7.4.2 or later
-** Ensure that the Host Guardian Service role is installed (refer to the https://learn.microsoft.com/en-us/windows-server/administration/server-manager/add-remove-roles-features?tabs=gui#add-roles-and-features-to-windows-server[Microsoft Windows Server documentation^] for instructions)
 ** Ensure that two-way HTTPS traffic is allowed for the following ports in the Windows Firewall settings:
 *** 8144 (NetApp Plugin for Hyper-V)
 *** 8145 (NetApp Plugin for Windows)


### PR DESCRIPTION
This pull request makes a minor update to the Hyper-V prerequisites documentation. The change removes the requirement for the Host Guardian Service role to be installed.