### PR TITLE
Hotfix: Remove legacy accounts limitation.

### DIFF
--- a/br-limitations-hyperv.adoc
+++ b/br-limitations-hyperv.adoc
@@ -25,17 +25,3 @@ The following actions are not supported in the private preview version of Hyper-
 * Protect VMs over SAN
 * Edit protection groups
 * Protect Hyper-V hosts that are clustered using System Center Virtual Machine Manager (SCVMM)
-
-== Unsupported legacy NetApp Console accounts
-
-Legacy NetApp Console accounts don't support the features required to protect Hyper-V workloads. Check if you are using a legacy account in the Console web UI. If you have a legacy Console account, create a new account before protecting Hyper-V workloads.
-
-.Steps
-
-. From the NetApp Console menu, select *Administration > Identity and access*.
-. Under *Organization*, check to see if an *Account ID* is shown next to the organization ID. 
-+
-If an *Account ID* is shown, you are using a legacy account.
-. If you are using a legacy account, do the following:
-.. Log out of the Console and then browse to the https://console.netapp.com/[Console login page^].
-.. Select *Sign up* to create a new account.

--- a/br-limitations-kvm.adoc
+++ b/br-limitations-kvm.adoc
@@ -38,16 +38,3 @@ The following configurations are not supported:
 * Disks spanned across multiple NFS mount points or shares
 * RAW disk format
 * Storage pool types other than NetFS (only NetFS is supported)
-
-== Unsupported legacy NetApp Console accounts
-Legacy NetApp Console accounts don't support the features required to protect KVM workloads. Check if you are using a legacy account in the Console web UI. If you have a legacy Console account, create a new account before protecting KVM workloads.
-
-.Steps
-
-. From the NetApp Console menu, select *Administration > Identity and access*.
-. Under *Organization*, check to see if an *Account ID* is shown next to the organization ID. 
-+
-If an *Account ID* is shown, you are using a legacy account.
-. If you are using a legacy account, do the following:
-.. Log out of the Console and then browse to the https://console.netapp.com/[Console login page^].
-.. Select *Sign up* to create a new account.


### PR DESCRIPTION
This pull request removes documentation related to unsupported legacy NetApp Console accounts from both the Hyper-V and KVM limitations guides. The removed sections previously explained how to identify and migrate from legacy accounts before protecting workloads.

This change was suggested by Vasantha Prabhu of KVM team.

Documentation cleanup:

* Removed the "Unsupported legacy NetApp Console accounts" section and related migration steps from `br-limitations-hyperv.adoc` to streamline the Hyper-V limitations documentation.
* Removed the "Unsupported legacy NetApp Console accounts" section and related migration steps from `br-limitations-kvm.adoc` to streamline the KVM limitations documentation.