### PR TITLE
Hotfix: Fixes for restore tasks for most workloads.

### DIFF
--- a/br-use-hyperv-restore.adoc
+++ b/br-use-hyperv-restore.adoc
@@ -89,20 +89,11 @@ A list of snapshots appears that match your search criteria.
 A list of possible restore points appears.
 . Select the restore point that you want to use.
 . Select a snapshot source location.
-
-
-
-
-
-. Select *Done* or *Next* to continue to the Restore destination settings page.
-+
-Next, you can choose the destination settings and the pre-restore and post-restore options.
+. Select *Next* to continue.
+. Choose the restore destination and settings:
 
 [discrete]
 ===== Destination selection
-
-[start=8]
-. Choose the destination settings and the pre-restore and post-restore options.
 
 //Start tabbed area 
 

--- a/br-use-kvm-restore.adoc
+++ b/br-use-kvm-restore.adoc
@@ -118,15 +118,12 @@ A list of possible restore points appears.
 //+
 //image:screen-vm-restore-location-objectstore-cost.png[A screenshot showing the Restore options for object storage.]
 
-. Select *Done* or *Next* to continue to the Restore destination settings page.
-+
-Next, you can choose the destination settings and the pre-restore and post-restore options.
+. Select *Next* to continue.
+. Choose the restore destination and settings:
 
 
 [discrete]
 ===== Destination selection
-
-. Choose the destination settings and the pre-restore and post-restore options.
 
 //Start tabbed area 
 

--- a/br-use-oracle-restore.adoc
+++ b/br-use-oracle-restore.adoc
@@ -123,14 +123,11 @@ The matching snapshots are displayed.
 ====
 
 . Select a snapshot source location.
-. Select *Next* to continue to the Restore destination settings page.
-+
-Next, you can choose the destination settings and the pre-restore and post-restore options.
+. Select *Next* to continue.
+. Choose the restore destination and settings:
 
 [discrete]
 ===== Destination selection
-
-. Choose the destination settings and the pre-restore and post-restore options.
 
 //Start tabbed area 
 

--- a/br-use-vmware-restore-vmdks-from-backups.adoc
+++ b/br-use-vmware-restore-vmdks-from-backups.adoc
@@ -61,8 +61,8 @@ Snapshot location options appear.
 +
 If you choose secondary storage, select the destination location from the drop-down list. 
 
-. Select *Next*.
-. Choose the destination settings and pre- and post-restore options:
+. Select *Next* to continue.
+. Choose the restore destination and settings:
 
 [discrete]
 ===== Destination selection

--- a/br-use-vmware-restore.adoc
+++ b/br-use-vmware-restore.adoc
@@ -98,8 +98,8 @@ Snapshot location options appear.
 +
 If you choose secondary storage, select the destination location from the drop-down list. 
   
-. Select *Next*.
-. Choose the destination settings and pre- and post-restore options.
+. Select *Next* to continue.
+. Choose the restore destination and settings:
 
 [discrete]
 ===== Destination selection


### PR DESCRIPTION
This pull request updates the restore workflow documentation across several files to streamline and clarify the instructions for selecting restore destinations and related options. The changes unify the language used for advancing to destination settings and simplify the explanation of available options, especially for post-restore actions.

**Workflow and Instruction Consistency:**

* Standardized the instruction to use "*Select Next to continue.*" followed by a clear prompt to "Choose the restore destination and settings" across all relevant restore documentation files. [[1]](diffhunk://#diff-a22f2245545f2681485c81fbd080cbf0b5aeecbbcd7777845aaa8ed61c7eb4c2L92-L105) [[2]](diffhunk://#diff-99337d9c77e9c6cb740e56ddcd73d5c41f544a2f35e2cb16df1b35bafc535b8dL121-L130) [[3]](diffhunk://#diff-fb772ab165382444af76fd527701f8a736b9414e789088dc1352d3ceaa580ab8L126-L134) [[4]](diffhunk://#diff-bbb8f50ecec75fae3db05e5a700662b329bf68b3a06dd423fee9cf5fbbb614aaL64-R65) [[5]](diffhunk://#diff-00ef5c9d720a80d7ccaa569246e150305e4c69d0f5dd2c03b81cfa0923c95963L101-R102)

**Simplification of Restore Options:**

* In `br-use-hyperv-restore.adoc`, replaced a detailed breakdown of destination and restore options with a simplified explanation, focusing on the inability to change destination settings when restoring to the original location and highlighting the main post-restore option ("Restart the virtual machine").

These changes improve the clarity and consistency of the restore process documentation, making it easier for users to follow the steps regardless of the platform.