### PR TITLE
Hotfix: Release notes fixes.

### DIFF
--- a/_whatsnew/2026-01-19.adoc
+++ b/_whatsnew/2026-01-19.adoc
@@ -11,8 +11,6 @@ This release of VMware workloads introduces the following enhanced capabilities:
 * VMware workload support is now generally available (GA) in NetApp Backup and Recovery.
 * You can now restore guest OS files and folders.
 
-https://docs.netapp.com/us-en/data-services-backup-recovery/br-use-vmware-protect-overview.html[Learn more about restoring VMware VMs with NetApp Backup and Recovery].
-
 https://docs.netapp.com/us-en/data-services-backup-recovery/br-use-vmware-restore-guest-files-and-folders-overview.html[Learn more about restoring guest files and folders].
 
 === Hyper-V workloads preview enhancements


### PR DESCRIPTION
This pull request updates the release notes to improve clarity and consistency in the descriptions of new backup and recovery features for VMware, Hyper-V, and KVM workloads. The most important changes are grouped by workload type below.

**VMware workload enhancements:**

* Corrected a duplicate phrase in the description of VMware workload support now being generally available (GA) in NetApp Backup and Recovery.
* Removed a redundant documentation link for restoring VMware VMs, keeping only the link for restoring guest files and folders.

**Hyper-V workload enhancements:**

* Reworded the description of restoring Hyper-V VM backups and snapshots to an alternate location for clarity.
* Clarified support for Hyper-V VMs provisioned by System Center Virtual Machine Manager (SCVMM) and hosted on CIFS shares.

**KVM workload enhancements:**

* Simplified the description of KVM workloads preview support for Apache CloudStack, clarifying that it protects KVM hosts and VMs managed by CloudStack.