### PR TITLE
Hotfix: Typo in what's new announcement.

### DIFF
--- a/_whatsnew/2026-02-23.adoc
+++ b/_whatsnew/2026-02-23.adoc
@@ -3,7 +3,7 @@ KVM workload support is now generally available (GA) in NetApp Backup and Recove
 
 For details about protecting KVM workloads, refer to https://docs.netapp.com/us-en/data-services-backup-recovery/br-use-kvm-protect-overview.html[Protect KVM workloads overview].
 
-=== Kubernetes supported in General Availability (GA)
+=== Kubernetes workloads supported in General Availability (GA)
 Kubernetes workload support is now generally available (GA) in NetApp Backup and Recovery. This release of Kubernetes workloads also introduces the following enhanced capabilities:
 
 *Reporting support*: You can now generate protection activity reports for Kubernetes clusters and applications protected by NetApp Backup and Recovery.


### PR DESCRIPTION
This pull request makes a small but important correction to the documentation, clarifying the scope of General Availability (GA) support in NetApp Backup and Recovery.

- Documentation update:
  * Corrected the feature announcement to state that KVM workload support (not Microsoft Hyper-V) is now generally available (GA) in NetApp Backup and Recovery.