### PR TITLE
Hotfix: Link fixes.

### DIFF
--- a/_include/namespace-anno-labels.adoc
+++ b/_include/namespace-anno-labels.adoc
@@ -13,7 +13,7 @@ helm upgrade trident-protect -n trident-protect netapp-trident-protect/trident-p
   --reuse-values
 -----
 
-NOTE: When performing restore or failover operation, any namespace annotations and labels specified in `restoreSkipNamespaceAnnotations` and `restoreSkipNamespaceLabels` are excluded from the restore or failover operation. Ensure these settings are configured during the initial Helm installation. To learn more, refer to link:../trident-protect/trident-protect-customize-installation.html#configure-additional-trident-protect-helm-chart-settings[Configure additional Trident Protect helm chart settings].
+NOTE: When performing restore or failover operation, any namespace annotations and labels specified in `restoreSkipNamespaceAnnotations` and `restoreSkipNamespaceLabels` are excluded from the restore or failover operation. Ensure these settings are configured during the initial Helm installation. To learn more, refer to https://docs.netapp.com/us-en/trident/trident-protect/trident-protect-customize-installation.html#configure-additional-trident-protect-helm-chart-settings[Configure additional Trident Protect helm chart settings].
 
 If you installed the source application using Helm with the `--create-namespace` flag, special treatment is given to the `name` label key. During the restore or failover process, Trident Protect copies this label to the destination namespace, but updates the value to the destination namespace value if the value from source matches the source namespace. If this value doesn't match the source namespace it is copied to the destination namespace with no changes. 
 


### PR DESCRIPTION
This pull request updates a documentation link in the `_include/namespace-anno-labels.adoc` file to point to the correct external URL for configuring additional Trident Protect Helm chart settings.

Documentation update:

* Changed the reference link for configuring additional Trident Protect Helm chart settings from a relative link to the full external NetApp documentation URL.