### PR TITLE
Hotfix: BLUEXPDOC-1132, BLUEXPDOC-1212, BLUEXPDOC-1213 for preview and hidden B&R features.

### DIFF
--- a/_whatsnew/2026-04-20.adoc
+++ b/_whatsnew/2026-04-20.adoc
@@ -1,6 +1,6 @@
 === VMware workloads enhancements
 In this release, VMware workloads introduces the following enhancement:
 
-* *ASA r2 SAN support*: VMware workloads now supports protecting VMs on VMFS datastores hosted by NetApp ASA r2 SAN-only environments.
+*ASA r2 SAN support*: VMware workloads now supports protecting VMs on VMFS datastores hosted by NetApp ASA r2 SAN-only environments.
 
 For details about protecting VMware workloads, refer to https://docs.netapp.com/us-en/data-services-backup-recovery/br-use-vmware-protect-overview.html[Protect VMware workloads overview].

--- a/change-advanced-settings.adoc
+++ b/change-advanced-settings.adoc
@@ -1,0 +1,98 @@
+---
+sidebar: sidebar
+permalink: enable-preview-features.html
+keywords: advanced settings, settings, Backup and Recovery, configuration, NetApp Backup and Recovery
+summary: Change advanced settings for NetApp Backup and Recovery.
+---
+
+= Enable preview features for NetApp Backup and Recovery
+:hardbreaks:
+:nofooter:
+:icons: font
+:linkattrs:
+:imagesdir: ./media/
+
+[.lead]
+Enable preview features and change advanced settings for NetApp Backup and Recovery. These system-level options affect backup behavior, retention, object-store integration, and preview features. Some settings require administrator roles.
+
+*Required NetApp Console role*
+Backup and Recovery super admin. Learn about link:reference-roles.html[Backup and recovery roles and privileges]. https://docs.netapp.com/us-en/console-setup-admin/reference-iam-predefined-roles.html[Learn about NetApp Console access roles for all services^].
+
+== Before you begin
+
+* Review your change with your team or administrator; some advanced settings affect all workloads.
+* Check release notes and known limitations for the current product version.
+
+
+== Enable preview features in Backup and Recovery
+Enable preview feature flag options to use functionality that is not yet generally available. Use preview features with caution in production.
+
+.Available preview feature flags
+
+[%header,cols="30,70"]
+|===
+|Feature flag |Feature description
+|folder-restore-from-local | Enable selecting and restoring folders from ONTAP volumes. ONTAP does not natively support restoring folders from local snapshots (but you can restore folders from object storage backups). When you enable this flag, you can restore entire directories from local and replicated snapshots.
+|prioritize-restore |Enable this feature flag to make the *Prioritize restore over existing job queue* option selectable during the restore workflow in the Backup and Recovery web UI. When you select this option in the restore workflow, restore jobs are prioritized over other queued jobs so they run even when the queue is busy.
+|===
+
+.Steps
+
+. Use SSH to log into the Console agent.
+. Change to the root user:
++
+[source,console]
+----
+sudo su
+----
+. Find the Backup and Recovery volume in Docker:
++
++
+[source,console]
+----
+docker volume ls | grep cbs
+----
++ 
+The output should be similar to the following:
++
+----
+local service-manager-2_cloudmanager_cbs_volume
+----
+. Find the mount point for the volume:
++
+[source,console]
+----
+docker volume inspect service-manager-2_cloudmanager_cbs_volume | grep Mountpoint
+----
++
+The mount point differs between cloud and private deployments. This output example shows a cloud deployment:
++
+----
+/var/lib/docker/volumes/service-manager-2_cloudmanager_cbs_volume/_data
+----
+. Change to the docker volume config directory, which is inside the mountpoint directory. For example:
++
+[source,console]
+----
+cd /var/lib/docker/volumes/service-manager-2_cloudmanager_cbs_volume/_data/cbs_config
+----
+. Create a config file named `preview-feature-flags.json` that contains the following JSON structure and a key/value pair for each feature flag you want to enable. Each feature flag key should have a corresponding value of `true`. For example:
++
+[source,json]
+----
+{
+  "feature-flags": {
+    "folder-restore-from-local": true
+  }
+}
+----
+. Restart the Backup and Recovery container:
++
+[source,console]
+----
+docker restart cloudmanager_cbs
+----
+. Reload the Backup and Recovery UI in your web browser and try a restore.
+
+
+

--- a/enable-preview-features.adoc
+++ b/enable-preview-features.adoc
@@ -27,8 +27,9 @@ Enable preview feature flag options to use functionality that is not yet general
 [%header,cols="30,70"]
 |===
 |Feature flag |Feature description
-|`folder-restore-from-local` |Enables folder-level restore from local ONTAP volume snapshots. By default, ONTAP only supports restoring folders from object storage backups. With this flag enabled, you can also restore entire directories from local and replicated snapshots.
-|`prioritize-restore` |Enable this feature flag to make the *Prioritize restore over existing job queue* option selectable during the restore workflow in the Backup and Recovery web UI. When you select this option during the restore workflow, restore operations are prioritized over other queued jobs so they run even when the queue is busy.
+|`"folder-restore-from-local": true` |Enables folder-level restore from local ONTAP volume snapshots. By default, ONTAP only supports restoring folders from object storage backups. With this flag enabled, you can also restore entire directories from local and replicated snapshots.
+|`"prioritize-restore": true` |Makes the *Prioritize restore over existing job queue* option selectable during the restore workflow in the Backup and Recovery web UI. When you select this option during the restore workflow, restore operations are prioritized over other queued jobs so they run even when the queue is busy.
+|`"svm-not-to-index": <storage_vm_name>` |Use this flag with the name of an ONTAP storage VM to disable indexing for all volumes that belong to that storage VM.
 |===
 
 .Steps
@@ -70,7 +71,7 @@ The mount point differs between cloud and private deployments. This output examp
 ----
 cd /var/lib/docker/volumes/service-manager-2_cloudmanager_cbs_volume/_data/cbs_config
 ----
-. Create a file named `preview-feature-flags.json` that contains the following JSON structure and a key/value pair for each feature flag you want to enable. Each feature flag key should have a corresponding value of `true`. For example:
+. Create a file named `preview-feature-flags.json` that contains the following JSON structure and a key/value pair for each feature flag you want to enable. Refer to <<Available preview feature flags>> for flag information. For example:
 +
 [source,json]
 ----

--- a/enable-preview-features.adoc
+++ b/enable-preview-features.adoc
@@ -42,7 +42,6 @@ sudo su
 ----
 . Find the Backup and Recovery volume in Docker:
 +
-+
 [source,console]
 ----
 docker volume ls | grep cbs
@@ -71,7 +70,7 @@ The mount point differs between cloud and private deployments. This output examp
 ----
 cd /var/lib/docker/volumes/service-manager-2_cloudmanager_cbs_volume/_data/cbs_config
 ----
-. Create a config file named `preview-feature-flags.json` that contains the following JSON structure and a key/value pair for each feature flag you want to enable. Each feature flag key should have a corresponding value of `true`. For example:
+. Create a file named `preview-feature-flags.json` that contains the following JSON structure and a key/value pair for each feature flag you want to enable. Each feature flag key should have a corresponding value of `true`. For example:
 +
 [source,json]
 ----
@@ -87,4 +86,4 @@ cd /var/lib/docker/volumes/service-manager-2_cloudmanager_cbs_volume/_data/cbs_c
 ----
 docker restart cloudmanager_cbs
 ----
-. Reload the Backup and Recovery UI in your web browser and try a restore.
+. Reload the Backup and Recovery UI in your web browser.

--- a/enable-preview-features.adoc
+++ b/enable-preview-features.adoc
@@ -21,10 +21,11 @@ Backup and Recovery super admin. Learn about link:reference-roles.html[Backup an
 == Enable preview features in Backup and Recovery
 Enable preview feature flag options to use functionality that is not yet generally available. Use preview features with caution in production environments.
 
+[[anchor-flags]]
 [caption=]
 .Available preview feature flags
 
-[%header,cols="30,70"]
+[%header,cols="50,50"]
 |===
 |Feature flag |Feature description
 |`"folder-restore-from-local": true` |Enables folder-level restore from local ONTAP volume snapshots. By default, ONTAP only supports restoring folders from object storage backups. With this flag enabled, you can also restore entire directories from local and replicated snapshots.
@@ -71,7 +72,7 @@ The mount point differs between cloud and private deployments. This output examp
 ----
 cd /var/lib/docker/volumes/service-manager-2_cloudmanager_cbs_volume/_data/cbs_config
 ----
-. Create a file named `preview-feature-flags.json` that contains the following JSON structure and a key/value pair for each feature flag you want to enable. Refer to <<Available preview feature flags>> for flag information. For example:
+. Create a file named `preview-feature-flags.json` that contains the following JSON structure and a key/value pair for each feature flag you want to enable. Refer to <<anchor-flags,available flags>> for flag information. For example:
 +
 [source,json]
 ----

--- a/enable-preview-features.adoc
+++ b/enable-preview-features.adoc
@@ -30,7 +30,6 @@ Enable preview feature flag options to use functionality that is not yet general
 |Feature flag |Feature description
 |`"folder-restore-from-local": true` |Enables folder-level restore from local ONTAP volume snapshots. By default, ONTAP only supports restoring folders from object storage backups. With this flag enabled, you can also restore entire directories from local and replicated snapshots.
 |`"prioritize-restore": true` |Makes the *Prioritize restore over existing job queue* option selectable during the restore workflow in the Backup and Recovery web UI. When you select this option during the restore workflow, restore operations are prioritized over other queued jobs so they run even when the queue is busy.
-|`"svm-not-to-index": <storage_vm_name>` |Use this flag with the name of an ONTAP storage VM to disable indexing for all volumes that belong to that storage VM.
 |===
 
 .Steps
@@ -132,15 +131,13 @@ The mount point differs between cloud and private deployments. This output examp
 ----
 cd /var/lib/docker/volumes/service-manager-2_cloudmanager_cbs_volume/_data/cbs_catalog_config
 ----
-. Create a file named `svm-no-indexing.json` that contains the following content:
+. Create a file named `svm-no-indexing.json` with the following content. Replace the storage VM names in the example with the names of the storage VMs in your environment:
 +
 [source,json]
 ----
 {
   "indexing": {
-    "index-scaleout-config": {
-      "max-workers": 2
-    }
+    "svms-not-to-index": "storage_vm_1,storage_vm_2,storage_vm_3"
   }
 }
 ----

--- a/enable-preview-features.adoc
+++ b/enable-preview-features.adoc
@@ -97,6 +97,8 @@ Refer to <<anchor-flags,available flags>> for feature flag information. As an ex
 docker restart cloudmanager_cbs
 ----
 . Reload the Backup and Recovery UI in your web browser.
++
+NOTE: To disable a preview feature, follow the same steps but set the feature flag value to `false`.
 
 == Disable indexing for all volumes that belong to a storage VM
 Follow these steps to disable indexing for all volumes that belong to a specific storage VM, instead of disabling indexing for each individual volume.

--- a/enable-preview-features.adoc
+++ b/enable-preview-features.adoc
@@ -1,11 +1,11 @@
 ---
 sidebar: sidebar
 permalink: enable-preview-features.html
-keywords: advanced settings, settings, Backup and Recovery, configuration, NetApp Backup and Recovery
-summary: Change advanced settings for NetApp Backup and Recovery.
+keywords: preview features, preview, Backup and Recovery, configuration, NetApp Backup and Recovery
+summary: Enable preview and hidden features for NetApp Backup and Recovery.
 ---
 
-= Enable preview features for NetApp Backup and Recovery
+= Enable preview and hidden features for NetApp Backup and Recovery
 :hardbreaks:
 :nofooter:
 :icons: font
@@ -13,7 +13,7 @@ summary: Change advanced settings for NetApp Backup and Recovery.
 :imagesdir: ./media/
 
 [.lead]
-Enable preview features and change advanced settings for NetApp Backup and Recovery.
+Enable preview and hidden features for NetApp Backup and Recovery.
 
 *Required NetApp Console role*
 Backup and Recovery super admin. Learn about link:reference-roles.html[Backup and recovery roles and privileges]. https://docs.netapp.com/us-en/console-setup-admin/reference-iam-predefined-roles.html[Learn about NetApp Console access roles for all services^].
@@ -27,7 +27,7 @@ Enable preview feature flag options to use functionality that is not yet general
 [%header,cols="30,70"]
 |===
 |Feature flag |Feature description
-|`folder-restore-from-local` | Enable selecting and restoring folders from ONTAP volumes. ONTAP does not natively support restoring folders from local snapshots (but you can restore folders from object storage backups). When you enable this flag, you can restore entire directories from local and replicated snapshots.
+|`folder-restore-from-local` |Enables folder-level restore from local ONTAP volume snapshots. By default, ONTAP only supports restoring folders from object storage backups. With this flag enabled, you can also restore entire directories from local and replicated snapshots.
 |`prioritize-restore` |Enable this feature flag to make the *Prioritize restore over existing job queue* option selectable during the restore workflow in the Backup and Recovery web UI. When you select this option in the restore workflow, restore jobs are prioritized over other queued jobs so they run even when the queue is busy.
 |===
 
@@ -87,3 +87,64 @@ cd /var/lib/docker/volumes/service-manager-2_cloudmanager_cbs_volume/_data/cbs_c
 docker restart cloudmanager_cbs
 ----
 . Reload the Backup and Recovery UI in your web browser.
+
+== Disable indexing for all volumes that belong to a storage VM
+Follow these steps to disable indexing for all volumes that belong to a specific storage VM, instead of disabling indexing for each individual volume.
+
+.Steps
+
+. Use SSH to log into the Console agent.
+. Change to the root user:
++
+[source,console]
+----
+sudo su
+----
+. Find the Backup and Recovery volume in Docker:
++
+[source,console]
+----
+docker volume ls | grep cbs
+----
++ 
+The output should be similar to the following:
++
+----
+local service-manager-2_cloudmanager_cbs_volume
+----
+. Find the mount point for the volume:
++
+[source,console]
+----
+docker volume inspect service-manager-2_cloudmanager_cbs_volume | grep Mountpoint
+----
++
+The mount point differs between cloud and private deployments. This output example shows a cloud deployment:
++
+----
+/var/lib/docker/volumes/service-manager-2_cloudmanager_cbs_volume/_data
+----
+. Change to the docker volume config directory, which is inside the mountpoint directory. For example:
++
+[source,console]
+----
+cd /var/lib/docker/volumes/service-manager-2_cloudmanager_cbs_volume/_data/cbs_catalog_config
+----
+. Create a file named `svm-no-indexing.json` that contains the following content:
++
+[source,json]
+----
+{
+  "indexing": {
+    "index-scaleout-config": {
+      "max-workers": 2
+    }
+  }
+}
+----
+. Restart the Backup and Recovery indexing catalog container:
++
+[source,console]
+----
+docker restart cloudmanager_cbs_catalog
+----

--- a/enable-preview-features.adoc
+++ b/enable-preview-features.adoc
@@ -13,27 +13,22 @@ summary: Change advanced settings for NetApp Backup and Recovery.
 :imagesdir: ./media/
 
 [.lead]
-Enable preview features and change advanced settings for NetApp Backup and Recovery. These system-level options affect backup behavior, retention, object-store integration, and preview features. Some settings require administrator roles.
+Enable preview features and change advanced settings for NetApp Backup and Recovery.
 
 *Required NetApp Console role*
 Backup and Recovery super admin. Learn about link:reference-roles.html[Backup and recovery roles and privileges]. https://docs.netapp.com/us-en/console-setup-admin/reference-iam-predefined-roles.html[Learn about NetApp Console access roles for all services^].
 
-== Before you begin
-
-* Review your change with your team or administrator; some advanced settings affect all workloads.
-* Check release notes and known limitations for the current product version.
-
-
 == Enable preview features in Backup and Recovery
 Enable preview feature flag options to use functionality that is not yet generally available. Use preview features with caution in production.
 
+[caption=]
 .Available preview feature flags
 
 [%header,cols="30,70"]
 |===
 |Feature flag |Feature description
-|folder-restore-from-local | Enable selecting and restoring folders from ONTAP volumes. ONTAP does not natively support restoring folders from local snapshots (but you can restore folders from object storage backups). When you enable this flag, you can restore entire directories from local and replicated snapshots.
-|prioritize-restore |Enable this feature flag to make the *Prioritize restore over existing job queue* option selectable during the restore workflow in the Backup and Recovery web UI. When you select this option in the restore workflow, restore jobs are prioritized over other queued jobs so they run even when the queue is busy.
+|`folder-restore-from-local` | Enable selecting and restoring folders from ONTAP volumes. ONTAP does not natively support restoring folders from local snapshots (but you can restore folders from object storage backups). When you enable this flag, you can restore entire directories from local and replicated snapshots.
+|`prioritize-restore` |Enable this feature flag to make the *Prioritize restore over existing job queue* option selectable during the restore workflow in the Backup and Recovery web UI. When you select this option in the restore workflow, restore jobs are prioritized over other queued jobs so they run even when the queue is busy.
 |===
 
 .Steps
@@ -93,6 +88,3 @@ cd /var/lib/docker/volumes/service-manager-2_cloudmanager_cbs_volume/_data/cbs_c
 docker restart cloudmanager_cbs
 ----
 . Reload the Backup and Recovery UI in your web browser and try a restore.
-
-
-

--- a/enable-preview-features.adoc
+++ b/enable-preview-features.adoc
@@ -74,7 +74,12 @@ The mount point differs between cloud and private deployments. This output examp
 ----
 cd /var/lib/docker/volumes/service-manager-2_cloudmanager_cbs_volume/_data/cbs_config
 ----
-. Create a file named `preview-feature-flags.json` that contains the following JSON structure and a key/value pair for each feature flag you want to enable. Refer to <<anchor-flags,available flags>> for flag information. For example:
+. Create a file that contains the following JSON structure and a key/value pair for each feature flag you want to enable. Name the file based on your deployment type:
++
+* Cloud deployment: `production-customer.json`
+* Private / dark site deployment: `darksite-customer.json`
++
+Refer to <<anchor-flags,available flags>> for feature flag information. As an example:
 +
 [source,json]
 ----
@@ -134,7 +139,7 @@ The mount point differs between cloud and private deployments. This output examp
 ----
 cd /var/lib/docker/volumes/service-manager-2_cloudmanager_cbs_volume/_data/cbs_catalog_config
 ----
-. Create a file named `svm-no-indexing.json` with the following content. Replace the storage VM names in the example with the names of the storage VMs in your environment:
+. Create a file named `production-customer.json` with the following content. Replace the storage VM names in the example with the names of the storage VMs in your environment:
 +
 [source,json]
 ----

--- a/enable-preview-features.adoc
+++ b/enable-preview-features.adoc
@@ -18,8 +18,8 @@ Enable preview and hidden features for NetApp Backup and Recovery.
 *Required NetApp Console role*
 Backup and Recovery super admin. Learn about link:reference-roles.html[Backup and recovery roles and privileges]. https://docs.netapp.com/us-en/console-setup-admin/reference-iam-predefined-roles.html[Learn about NetApp Console access roles for all services^].
 
-== Enable preview features in Backup and Recovery
-Enable preview feature flag options to use functionality that is not yet generally available. Use preview features with caution in production environments.
+== Available preview features
+You can enable the following preview features for NetApp Backup and Recovery.
 
 [[anchor-flags]]
 [caption=]
@@ -31,6 +31,9 @@ Enable preview feature flag options to use functionality that is not yet general
 |`"folder-restore-from-local": true` |Enables folder-level restore from local ONTAP volume snapshots. By default, ONTAP only supports restoring folders from object storage backups. With this flag enabled, you can also restore entire directories from local and replicated snapshots.
 |`"prioritize-restore": true` |Makes the *Prioritize restore over existing job queue* option selectable during the restore workflow in the Backup and Recovery web UI. When you select this option during the restore workflow, restore operations are prioritized over other queued jobs so they run even when the queue is busy.
 |===
+
+== Enable preview features
+Enable preview feature flag options to use functionality that is not yet generally available. Use preview features with caution in production environments.
 
 .Steps
 

--- a/enable-preview-features.adoc
+++ b/enable-preview-features.adoc
@@ -19,7 +19,7 @@ Enable preview and hidden features for NetApp Backup and Recovery.
 Backup and Recovery super admin. Learn about link:reference-roles.html[Backup and recovery roles and privileges]. https://docs.netapp.com/us-en/console-setup-admin/reference-iam-predefined-roles.html[Learn about NetApp Console access roles for all services^].
 
 == Enable preview features in Backup and Recovery
-Enable preview feature flag options to use functionality that is not yet generally available. Use preview features with caution in production.
+Enable preview feature flag options to use functionality that is not yet generally available. Use preview features with caution in production environments.
 
 [caption=]
 .Available preview feature flags
@@ -28,7 +28,7 @@ Enable preview feature flag options to use functionality that is not yet general
 |===
 |Feature flag |Feature description
 |`folder-restore-from-local` |Enables folder-level restore from local ONTAP volume snapshots. By default, ONTAP only supports restoring folders from object storage backups. With this flag enabled, you can also restore entire directories from local and replicated snapshots.
-|`prioritize-restore` |Enable this feature flag to make the *Prioritize restore over existing job queue* option selectable during the restore workflow in the Backup and Recovery web UI. When you select this option in the restore workflow, restore jobs are prioritized over other queued jobs so they run even when the queue is busy.
+|`prioritize-restore` |Enable this feature flag to make the *Prioritize restore over existing job queue* option selectable during the restore workflow in the Backup and Recovery web UI. When you select this option during the restore workflow, restore operations are prioritized over other queued jobs so they run even when the queue is busy.
 |===
 
 .Steps

--- a/enable-preview-features.adoc
+++ b/enable-preview-features.adoc
@@ -85,7 +85,8 @@ Refer to <<anchor-flags,available flags>> for feature flag information. As an ex
 ----
 {
   "feature-flags": {
-    "folder-restore-from-local": true
+    "folder-restore-from-local": true,
+    "prioritize-restore": true
   }
 }
 ----

--- a/project.yml
+++ b/project.yml
@@ -257,7 +257,7 @@ sidebar:
           url: /br-use-monitor-tasks.html
         - title: Restart NetApp Backup and Recovery
           url: /reference-restart-backup.html
-        - title: Enable preview features for NetApp Backup and Recovery
+        - title: Enable preview and hidden features
           url: /enable-preview-features.html
     - title: Automate with the REST API
       url: /br-api-backup-restore.html          

--- a/project.yml
+++ b/project.yml
@@ -257,6 +257,8 @@ sidebar:
           url: /br-use-monitor-tasks.html
         - title: Restart NetApp Backup and Recovery
           url: /reference-restart-backup.html
+        - title: Enable preview features for NetApp Backup and Recovery
+          url: /enable-preview-features.html
     - title: Automate with the REST API
       url: /br-api-backup-restore.html          
     - title: Reference 


### PR DESCRIPTION
This pull request introduces documentation for enabling preview and hidden features in NetApp Backup and Recovery, and adds instructions for disabling indexing for all volumes in a storage VM. It also adds a new entry to the sidebar navigation for easy access to this content. Additionally, there is a minor formatting fix in the VMware workloads enhancements section.

**Documentation Additions and Improvements:**

* Added a new guide, `enable-preview-features.adoc`, which details how to enable preview and hidden features for NetApp Backup and Recovery using feature flags, including step-by-step instructions for both cloud and private deployments. This guide also documents how to disable indexing for all volumes in a storage VM.
* Updated the sidebar navigation in `project.yml` to include a link to the new "Enable preview and hidden features" documentation, improving discoverability.

**Minor Fixes:**

* Fixed formatting in the VMware workloads enhancements section by removing unnecessary bolding from "ASA r2 SAN support" in `_whatsnew/2026-04-20.adoc`.