### PR TITLE
GitHub issue 81 fix.

### DIFF
--- a/br-use-hyperv-restore.adoc
+++ b/br-use-hyperv-restore.adoc
@@ -32,7 +32,7 @@ You can restore data to these points:
 
 .Restore from object storage considerations
 
-If you select a backup file in object storage, and ransomware protection is active for that backup (if you enabled DataLock and Ransomware Resilience in the backup policy), then you are prompted to run an additional integrity check on the backup file before restoring the data. We recommend that you perform the scan. 
+If you select a backup file in object storage, and ransomware protection is active for that backup (if you enabled Datalock and Ransomware protection in the backup policy), then you are prompted to run an additional integrity check on the backup file before restoring the data. We recommend that you perform the scan. 
 
 TIP: You'll incur extra egress costs from your cloud provider to access the contents of the backup file.
 

--- a/br-use-kvm-restore.adoc
+++ b/br-use-kvm-restore.adoc
@@ -38,7 +38,7 @@ You can restore data to these points:
 
 .Restore from object storage considerations
 
-If you select a backup file in object storage, and ransomware protection is active for that backup (if you enabled DataLock and Ransomware Resilience in the backup policy), then you are prompted to run an additional integrity check on the backup file before restoring the data. We recommend that you perform the scan. 
+If you select a backup file in object storage, and ransomware protection is active for that backup (if you enabled Datalock and Ransomware protection in the backup policy), then you are prompted to run an additional integrity check on the backup file before restoring the data. We recommend that you perform the scan. 
 
 TIP: You'll incur extra egress costs from your cloud provider to access the contents of the backup file.
 

--- a/br-use-mssql-restore.adoc
+++ b/br-use-mssql-restore.adoc
@@ -33,7 +33,7 @@ You can restore data to the latest snapshot or to these points:
 
 .Restore from object storage considerations
 
-If you select a backup file in object storage, and Ransomware Resilience is active for that backup (if you enabled DataLock and Ransomware Resilience in the backup policy), then you are prompted to run an additional integrity check on the backup file before restoring the data. We recommend that you perform the scan. 
+If you select a backup file in object storage, and ransomware protection is active for that backup (if you enabled Datalock and Ransomware protection in the backup policy), then you are prompted to run an additional integrity check on the backup file before restoring the data. We recommend that you perform the scan. 
 
 TIP: You pay extra fees to your cloud provider to access the backup file.
 

--- a/br-use-oracle-restore.adoc
+++ b/br-use-oracle-restore.adoc
@@ -32,7 +32,7 @@ You can restore data to the original location; restoring to an alternate locatio
 
 //.Restore from object storage considerations
 
-//If you select a backup file in object storage, and ransomware protection is active for that backup (if you enabled DataLock and Ransomware Resilience in the backup policy), then you are prompted to run an additional integrity check on the backup file before restoring the data. We recommend that you perform the scan. 
+//If you select a backup file in object storage, and ransomware protection is active for that backup (if you enabled Datalock and Ransomware protection in the backup policy), then you are prompted to run an additional integrity check on the backup file before restoring the data. We recommend that you perform the scan. 
 
 //TIP: You'll incur extra egress costs from your cloud provider to access the contents of the backup file.
 

--- a/br-use-vmware-restore.adoc
+++ b/br-use-vmware-restore.adoc
@@ -36,7 +36,7 @@ You can restore data to these points:
 
 .Restore from object storage considerations
 
-If Ransomware Resilience is enabled for a backup file in object storage, you are asked to run an extra check before restoring. We recommend performing the scan.
+If ransomware protection is enabled for a backup file in object storage, you are asked to run an extra check before restoring. We recommend performing the scan.
 
 TIP: You might pay extra fees to your cloud provider to access the backup file.
 

--- a/concept-backup-to-cloud.adoc
+++ b/concept-backup-to-cloud.adoc
@@ -127,7 +127,7 @@ Because NetApp Backup and Recovery preserves the storage efficiencies of the sou
 
 * If you plan to restore volume data from a backup file that has been moved to archival object storage, then there's an additional per-GiB retrieval fee and per-request fee from the cloud provider.
 
-* If you plan to scan a backup file for ransomware during the process of restoring volume data (if you enabled DataLock and Ransomware Resilience for your cloud backups), then you'll incur extra egress costs from your cloud provider as well.
+* If you plan to scan a backup file for ransomware during the process of restoring volume data (if you enabled Datalock and Ransomware protection for your cloud backups), then you'll incur extra egress costs from your cloud provider as well.
 
 *Service charges*
 

--- a/prev-ontap-backup-cvo-aws.adoc
+++ b/prev-ontap-backup-cvo-aws.adoc
@@ -346,7 +346,7 @@ To create a policy, select *Create new policy* and do the following:
 +
 .. Enter the name of the policy. 
 .. Select up to five schedules, typically of different frequencies. 
-.. For backup-to-object policies, set the DataLock and Ransomware Resilience settings. For details on DataLock and Ransomware Resilience, refer to link:prev-ontap-policy-object-options.html[Backup-to-object policy settings].
+.. For backup-to-object policies, set the Datalock and Ransomware protection settings. For details on Datalock and Ransomware protection, refer to link:prev-ontap-policy-object-options.html[Backup-to-object policy settings].
 .. Select *Create*.
 
 * *Export existing snapshot*: If there are any local snapshots for volumes in this system that match the backup schedule label you just selected for this system (for example, daily, weekly, etc.), this additional prompt is displayed. Check this box to have all historic snapshots copied to object storage as backup files to ensure the most complete protection for your volumes.

--- a/prev-ontap-backup-cvo-azure.adoc
+++ b/prev-ontap-backup-cvo-azure.adoc
@@ -355,7 +355,7 @@ TIP: To create a custom policy before activating the backup, refer to link:br-us
 To create a policy, select *Create new policy* and do the following: 
 +
 ** Enter the name of the policy. 
-** For backup-to-object policies, set the DataLock and Ransomware Resilience settings. For details on DataLock and Ransomware Resilience, refer to link:prev-ontap-policy-object-options.html[Backup-to-object policy settings].
+** For backup-to-object policies, set the Datalock and Ransomware protection settings. For details on Datalock and Ransomware protection, refer to link:prev-ontap-policy-object-options.html[Backup-to-object policy settings].
 // In backup to object only (not snapshots and replication) for CVO to AWS, CVO to Azure, onprem to AWS, Azure, S3, and SG - can do Advanced Settings for ransomware scans and datalock. Adv Settings does not apply to Google.)
 
 ** Select up to five schedules, typically of different frequencies. 
@@ -368,7 +368,7 @@ To create a policy, select *Create new policy* and do the following:
 //.. Enter the name for the default policy. You don't need to change the name.
 //.. Define the backup schedule and choose the number of backups to retain. link:concept-ontap-backup-to-cloud.html#customizable-backup-schedule-and-retention-settings[See the list of existing policies you can choose^].
 
-//.. Optionally, when using ONTAP 9.11.1 and greater, you can choose to protect your backups from deletion and ransomware attacks by configuring one of the _DataLock and Ransomware Resilience_ settings. _DataLock_ protects your backup files from being modified or deleted, and _Ransomware protection_ scans your backup files to look for evidence of a ransomware attack in your backup files. link:concept-cloud-backup-policies.html#datalock-and-ransomware-protection[Learn more about the available DataLock settings^].
+//.. Optionally, when using ONTAP 9.11.1 and greater, you can choose to protect your backups from deletion and ransomware attacks by configuring one of the _Datalock and Ransomware protection_ settings. _DataLock_ protects your backup files from being modified or deleted, and _Ransomware protection_ scans your backup files to look for evidence of a ransomware attack in your backup files. link:concept-cloud-backup-policies.html#datalock-and-ransomware-protection[Learn more about the available DataLock settings^].
 //+
 //NOTE: If you plan to use DataLock, you must enable it in your first policy when activating NetApp Backup and Recovery. You might want to protect your backups from deletion by using _DataLock_.
 

--- a/prev-ontap-backup-cvo-gcp.adoc
+++ b/prev-ontap-backup-cvo-gcp.adoc
@@ -371,7 +371,7 @@ To create a policy, select *Create new policy* and do the following:
 +
 ** Enter the name of the policy. 
 ** Select up to five schedules, typically of different frequencies. 
-** For backup-to-object policies, configure Datalock and Ransomware Resilience. For details on Datalock and Ransomware Resilience, refer to link:prev-ontap-policy-object-options.html[Backup-to-object policy settings].
+** For backup-to-object policies, configure Datalock and Ransomware protection. For details on Datalock and Ransomware protection, refer to link:prev-ontap-policy-object-options.html[Backup-to-object policy settings].
 ** Select *Create*. 
 . *Replication*: Set the following options: 
 +
@@ -419,7 +419,7 @@ To create a policy, select *Create new policy* and do the following:
 //.. Enter the name for the default policy. You don't need to change the name.
 //.. Define the backup schedule and choose the number of backups to retain. link:concept-ontap-backup-to-cloud.html#customizable-backup-schedule-and-retention-settings[See the list of existing policies you can choose^].
 
-//.. Optionally, when using ONTAP 9.11.1 and greater, you can choose to protect your backups from deletion and ransomware attacks by configuring one of the _DataLock and Ransomware Resilience_ settings. _DataLock_ protects your backup files from being modified or deleted, and _Ransomware protection_ scans your backup files to look for evidence of a ransomware attack in your backup files. link:concept-cloud-backup-policies.html#datalock-and-ransomware-protection[Learn more about the available DataLock settings^].
+//.. Optionally, when using ONTAP 9.11.1 and greater, you can choose to protect your backups from deletion and ransomware attacks by configuring one of the _Datalock and Ransomware protection_ settings. _DataLock_ protects your backup files from being modified or deleted, and _Ransomware protection_ scans your backup files to look for evidence of a ransomware attack in your backup files. link:concept-cloud-backup-policies.html#datalock-and-ransomware-protection[Learn more about the available DataLock settings^].
 //+
 //NOTE: If you plan to use DataLock, you must enable it in your first policy when activating NetApp Backup and Recovery. You might want to protect your backups from deletion by using _DataLock_.
 

--- a/prev-ontap-backup-manage.adoc
+++ b/prev-ontap-backup-manage.adoc
@@ -66,7 +66,7 @@ You can change the backup policies assigned to your existing volumes that have a
 
 . In the _Edit backup strategy_ page, make changes to the existing backup policies for Local snapshots, Replicated volumes, and Backup files and select *Next*.
 +
-If you enabled _DataLock and Ransomware Resilience_ for cloud backups in the initial backup policy when activating NetApp Backup and Recovery for this cluster, you'll only see other policies that have been configured with DataLock. And if you did not enable _DataLock and Ransomware Resilience_ when activating NetApp Backup and Recovery, you'll only see other cloud backup policies that don't have DataLock configured.
+If you enabled _Datalock and Ransomware protection_ for cloud backups in the initial backup policy when activating NetApp Backup and Recovery for this cluster, you'll only see other policies that have been configured with DataLock. And if you did not enable _Datalock and Ransomware protection_ when activating NetApp Backup and Recovery, you'll only see other cloud backup policies that don't have DataLock configured.
 
 . Review the backup settings for this volume, and then select *Activate Backup*.
 
@@ -104,7 +104,7 @@ When more than five volumes are enabled for backup, NetApp Backup and Recovery i
 
 . In the backup page that appears, make changes to the existing backup policies for Local snapshots, Replicated volumes, or Backup files and select *Save*.
 +
-If you enabled _DataLock and Ransomware Resilience_ for cloud backups in the initial backup policy when activating NetApp Backup and Recovery for this cluster, you'll only see other policies that have been configured with DataLock. And if you did not enable _DataLock and Ransomware Resilience_ when activating NetApp Backup and Recovery, you'll only see other cloud backup policies that don't have DataLock configured.
+If you enabled _Datalock and Ransomware protection_ for cloud backups in the initial backup policy when activating NetApp Backup and Recovery for this cluster, you'll only see other policies that have been configured with DataLock. And if you did not enable _Datalock and Ransomware protection_ when activating NetApp Backup and Recovery, you'll only see other cloud backup policies that don't have DataLock configured.
 
 == Create a manual volume backup at any time
 
@@ -114,7 +114,7 @@ You can create an ad-hoc snapshot or backup to object store of a volume. You can
 
 The backup name includes the timestamp so you can identify your on-demand backup from other scheduled backups.
 
-If you enabled _DataLock and Ransomware Resilience_ when activating NetApp Backup and Recovery for this cluster, the on-demand backup also will be configured with DataLock, and the retention period will be 30 days. Ransomware scans are not supported for ad-hoc backups. link:prev-ontap-policy-object-options.html[Learn more about DataLock and Ransomware protection^].
+If you enabled _Datalock and Ransomware protection_ when activating NetApp Backup and Recovery for this cluster, the on-demand backup also will be configured with DataLock, and the retention period will be 30 days. Ransomware scans are not supported for ad-hoc backups. link:prev-ontap-policy-object-options.html[Learn more about DataLock and Ransomware protection^].
 
 When you create an ad-hoc backup, a snapshot is created on the source volume. Because this snapshot is not part of a normal snapshot schedule, it will not rotate off. You may want to manually delete this snapshot from the source volume once the backup is complete. This will allow blocks related to this snapshot to be freed up. The name of the Snapshot will begin with `cbs-snapshot-adhoc-`. https://docs.netapp.com/us-en/ontap/san-admin/delete-all-existing-snapshot-copies-volume-task.html[See how to delete a Snapshot using the ONTAP CLI^].
 
@@ -144,7 +144,7 @@ The details for the volume and the list of snapshots are displayed.
 
 NetApp Backup and Recovery scans your backup files to look for evidence of a ransomware attack when a backup to object file is created, and when data from a backup file is being restored. You can also run an on-demand scan at any time to verify the usability of a specific backup file in object storage. This can be useful if you have had a ransomware issue on a particular volume and you want to verify that the backups for that volume are not affected.
 
-This feature is available only if the volume backup was created from a system with ONTAP 9.11.1 or greater, and if you enabled _DataLock and Ransomware Resilience_ in the backup-to-object policy.
+This feature is available only if the volume backup was created from a system with ONTAP 9.11.1 or greater, and if you enabled _Datalock and Ransomware protection_ in the backup-to-object policy.
 
 .Steps
 
@@ -157,7 +157,7 @@ The details for the volume are displayed.
 
 . Select image:icon-actions-horizontal.gif[Actions icon] for the volume backup file you want to scan for ransomware and click *Scan for Ransomware*. 
 +
-The Ransomware Resilience column shows that the scan is In Progress.
+The ransomware protection column shows that the scan is In Progress.
 
 //== Disable backups of volumes
 //
@@ -234,7 +234,7 @@ You can change the attributes for a backup policy that is currently applied to v
 
 [NOTE]
 ====
-* If you enabled _DataLock and Ransomware Resilience_ in the initial policy when activating NetApp Backup and Recovery for this cluster, any policies that you edit must be configured with the same DataLock setting (Governance or Compliance). And if you did not enable _DataLock and Ransomware Resilience_ when activating NetApp Backup and Recovery, you can't enable DataLock now.
+* If you enabled _Datalock and Ransomware protection_ in the initial policy when activating NetApp Backup and Recovery for this cluster, any policies that you edit must be configured with the same DataLock setting (Governance or Compliance). And if you did not enable _Datalock and Ransomware protection_ when activating NetApp Backup and Recovery, you can't enable DataLock now.
 * When creating backups on AWS, if you chose _S3 Glacier_ or _S3 Glacier Deep Archive_ in your first backup policy when activating NetApp Backup and Recovery, then that tier will be the only archive tier available when editing backup policies. And if you selected no archive tier in your first backup policy, then _S3 Glacier_ will be your only archive option when editing a policy.
 ====
 
@@ -269,7 +269,7 @@ If you want to apply a new backup policy to certain volumes in a system, you fir
 
 [NOTE]
 ====
-* If you enabled _DataLock and Ransomware Resilience_ in the initial policy when activating NetApp Backup and Recovery for this cluster, any additional policies you create must be configured with the same DataLock setting (Governance or Compliance). And if you did not enable _DataLock and Ransomware Resilience_ when activating NetApp Backup and Recovery, you can't create new policies that use DataLock.
+* If you enabled _Datalock and Ransomware protection_ in the initial policy when activating NetApp Backup and Recovery for this cluster, any additional policies you create must be configured with the same DataLock setting (Governance or Compliance). And if you did not enable _Datalock and Ransomware protection_ when activating NetApp Backup and Recovery, you can't create new policies that use DataLock.
 * When creating backups on AWS, if you chose _S3 Glacier_ or _S3 Glacier Deep Archive_ in your first backup policy when activating NetApp Backup and Recovery, then that tier will be the only archive tier available for future backup policies for that cluster. And if you selected no archive tier in your first backup policy, then _S3 Glacier_ will be your only archive option for future policies.
 ====
 

--- a/prev-ontap-backup-onprem-aws.adoc
+++ b/prev-ontap-backup-onprem-aws.adoc
@@ -396,7 +396,7 @@ TIP: To create a custom policy before activating the snapshot, refer to link:br-
 +
 * Enter the name of the policy. 
 * Select up to five schedules, typically of different frequencies. 
-** For backup-to-object policies, set the DataLock and Ransomware Resilience settings. For details on DataLock and Ransomware Resilience, refer to link:prev-ontap-policy-object-options.html[Backup-to-object policy settings].
+** For backup-to-object policies, set the Datalock and Ransomware protection settings. For details on Datalock and Ransomware protection, refer to link:prev-ontap-policy-object-options.html[Backup-to-object policy settings].
 * Select *Create*.
 // In backup to object only (not snapshots and replication) for CVO to AWS, CVO to Azure, onprem to AWS, Azure, S3, and SG - can do Advanced Settings for ransomware scans and datalock. Adv Settings does not apply to Google.)
  
@@ -451,7 +451,7 @@ To create a policy, select *Create new policy* and do the following:
 //.. Enter the name for the default policy. You don't need to change the name.
 //.. Define the backup schedule and choose the number of backups to retain. link:concept-ontap-backup-to-cloud.html#customizable-backup-schedule-and-retention-settings[See the list of existing policies you can choose^].
 
-//.. Optionally, when using ONTAP 9.11.1 and greater, you can choose to protect your backups from deletion and ransomware attacks by configuring one of the _DataLock and Ransomware Resilience_ settings. _DataLock_ protects your backup files from being modified or deleted, and _Ransomware protection_ scans your backup files to look for evidence of a ransomware attack in your backup files. link:concept-cloud-backup-policies.html#datalock-and-ransomware-protection[Learn more about the available DataLock settings^].
+//.. Optionally, when using ONTAP 9.11.1 and greater, you can choose to protect your backups from deletion and ransomware attacks by configuring one of the _Datalock and Ransomware protection_ settings. _DataLock_ protects your backup files from being modified or deleted, and _Ransomware protection_ scans your backup files to look for evidence of a ransomware attack in your backup files. link:concept-cloud-backup-policies.html#datalock-and-ransomware-protection[Learn more about the available DataLock settings^].
 //+
 //NOTE: If you plan to use DataLock, you must enable it in your first policy when activating NetApp Backup and Recovery. You might want to protect your backups from deletion by using _DataLock_.
 

--- a/prev-ontap-backup-onprem-azure.adoc
+++ b/prev-ontap-backup-onprem-azure.adoc
@@ -359,7 +359,7 @@ To create a policy, select *Create new policy* and do the following:
 
 ** Enter the name of the policy. 
 ** Select up to five schedules, typically of different frequencies. 
-** For backup-to-object policies, set the DataLock and Ransomware Resilience settings. For details on DataLock and Ransomware Resilience, refer to link:prev-ontap-policy-object-options.html[Backup-to-object policy settings].
+** For backup-to-object policies, set the Datalock and Ransomware protection settings. For details on Datalock and Ransomware protection, refer to link:prev-ontap-policy-object-options.html[Backup-to-object policy settings].
 ** Select *Create*. 
 // In backup to object only (not snapshots and replication) for CVO to AWS, CVO to Azure, onprem to AWS, Azure, S3, and SG - can do Advanced Settings for ransomware scans and datalock. Adv Settings does not apply to Google.)
 
@@ -372,7 +372,7 @@ To create a policy, select *Create new policy* and do the following:
 //.. Enter the name for the default policy. You don't need to change the name.
 //.. Define the backup schedule and choose the number of backups to retain. link:concept-ontap-backup-to-cloud.html#customizable-backup-schedule-and-retention-settings[See the list of existing policies you can choose^].
 
-//.. Optionally, when using ONTAP 9.11.1 and greater, you can choose to protect your backups from deletion and ransomware attacks by configuring one of the _DataLock and Ransomware Resilience_ settings. _DataLock_ protects your backup files from being modified or deleted, and _Ransomware protection_ scans your backup files to look for evidence of a ransomware attack in your backup files. 
+//.. Optionally, when using ONTAP 9.11.1 and greater, you can choose to protect your backups from deletion and ransomware attacks by configuring one of the _Datalock and Ransomware protection_ settings. _DataLock_ protects your backup files from being modified or deleted, and _Ransomware protection_ scans your backup files to look for evidence of a ransomware attack in your backup files. 
 //+
 //NOTE: If you plan to use DataLock, you must enable it in your first policy when activating NetApp Backup and Recovery. You might want to protect your backups from deletion by using _DataLock_.
 

--- a/prev-ontap-backup-onprem-gcp.adoc
+++ b/prev-ontap-backup-onprem-gcp.adoc
@@ -401,7 +401,7 @@ To create a policy, select *Create new policy* and do the following:
 //.. Enter the name for the default policy. You don't need to change the name.
 //.. Define the backup schedule and choose the number of backups to retain. link:concept-ontap-backup-to-cloud.html#customizable-backup-schedule-and-retention-settings[See the list of existing policies you can choose^].
 
-//.. Optionally, when using ONTAP 9.11.1 and greater, you can choose to protect your backups from deletion and ransomware attacks by configuring one of the _DataLock and Ransomware Resilience_ settings. _DataLock_ protects your backup files from being modified or deleted, and _Ransomware protection_ scans your backup files to look for evidence of a ransomware attack in your backup files. link:concept-cloud-backup-policies.html#datalock-and-ransomware-protection[Learn more about the available DataLock settings^].
+//.. Optionally, when using ONTAP 9.11.1 and greater, you can choose to protect your backups from deletion and ransomware attacks by configuring one of the _Datalock and Ransomware protection_ settings. _DataLock_ protects your backup files from being modified or deleted, and _Ransomware protection_ scans your backup files to look for evidence of a ransomware attack in your backup files. link:concept-cloud-backup-policies.html#datalock-and-ransomware-protection[Learn more about the available DataLock settings^].
 //+
 //NOTE: If you plan to use DataLock, you must enable it in your first policy when activating NetApp Backup and Recovery. You might want to protect your backups from deletion by using _DataLock_.
 

--- a/prev-ontap-backup-onprem-ontaps3.adoc
+++ b/prev-ontap-backup-onprem-ontaps3.adoc
@@ -129,7 +129,7 @@ Supported ONTAP versions::
 ONTAP 9.8 and later is required for on-premises ONTAP systems.
 ONTAP 9.9.1 and later is required for Cloud Volumes ONTAP systems.
 //+
-//To use DataLock & Ransomware Resilience for your backups, your ONTAP S3 systems must be running version 11.6.0.3 or greater. 
+//To use DataLock & Ransomware protection for your backups, your ONTAP S3 systems must be running version 11.6.0.3 or greater. 
 //+
 //To tier older backups to cloud archival storage, your ONTAP S3 systems must be running version 11.3 or greater. Additionally, your ONTAP S3 systems must be discovered to the NetApp Console.
 
@@ -293,13 +293,13 @@ To create a policy, select *Create new policy* and do the following:
 +
 ** Enter the name of the policy. 
 ** Select up to five schedules, typically of different frequencies. 
-** For backup-to-object policies, set the DataLock and Ransomware Resilience settings. For details on DataLock and Ransomware Resilience, refer to link:prev-ontap-policy-object-options.html[Backup-to-object policy settings].
+** For backup-to-object policies, set the Datalock and Ransomware protection settings. For details on Datalock and Ransomware protection, refer to link:prev-ontap-policy-object-options.html[Backup-to-object policy settings].
 ** Select *Create*. 
 // In backup to object only (not snapshots and replication) for CVO to AWS, CVO to Azure, onprem to AWS, Azure, S3, and SG - can do Advanced Settings for ransomware scans and datalock. Adv Settings does not apply to Google.)
 
 
 +
-//If your cluster is using ONTAP 9.11.1 or greater, you can choose to protect your backups from deletion and ransomware attacks by configuring _DataLock and Ransomware Resilience_. _DataLock_ protects your backup files from being modified or deleted, and _Ransomware protection_ scans your backup files to look for evidence of a ransomware attack in your backup files. link:concept-cloud-backup-policies.html#datalock-and-ransomware-protection[Learn more about the available DataLock settings^].
+//If your cluster is using ONTAP 9.11.1 or greater, you can choose to protect your backups from deletion and ransomware attacks by configuring _Datalock and Ransomware protection_. _DataLock_ protects your backup files from being modified or deleted, and _Ransomware protection_ scans your backup files to look for evidence of a ransomware attack in your backup files. link:concept-cloud-backup-policies.html#datalock-and-ransomware-protection[Learn more about the available DataLock settings^].
 //+
 //If your cluster is using ONTAP 9.12.1 or greater and your ONTAP S3 system is using version 11.4 or greater, you can choose to tier older backups to public cloud archive tiers after a certain number of days. Current support is for AWS S3 Glacier/S3 Glacier Deep Archive or Azure Archive storage tiers. <<Preparing to archive older backup files to public cloud storage,See how to configure your systems for this functionality>>.
 //

--- a/prev-ontap-backup-onprem-storagegrid.adoc
+++ b/prev-ontap-backup-onprem-storagegrid.adoc
@@ -120,12 +120,12 @@ StorageGRID must meet the following requirements. See the https://docs.netapp.co
 
 // Per MN, BYOB not supported in July 2023 release. 
 
-For details about DataLock and Ransomware Resilience requirements for StorageGRID, refer to link:prev-ontap-policy-object-options.html[Backup-to-object policy options].
+For details about Datalock and Ransomware protection requirements for StorageGRID, refer to link:prev-ontap-policy-object-options.html[Backup-to-object policy options].
 
 Supported StorageGRID versions::
 StorageGRID 10.3 and later is supported.
 +
-To use DataLock & Ransomware Resilience for your backups, your StorageGRID systems must be running version 11.6.0.3 or greater. 
+To use DataLock & Ransomware protection for your backups, your StorageGRID systems must be running version 11.6.0.3 or greater. 
 +
 To tier older backups to cloud archival storage, your StorageGRID systems must be running version 11.3 or greater. Additionally, your StorageGRID systems must be discovered to the Console *Systems* page.
 +
@@ -321,9 +321,9 @@ To create a policy, select *Create new policy* and do the following:
 +
 ** Enter the name of the policy. 
 ** Select up to five schedules, typically of different frequencies. 
-** For backup-to-object policies, set the DataLock and Ransomware Resilience settings. For details on DataLock and Ransomware Resilience, refer to link:prev-ontap-policy-object-options.html[Backup-to-object policy settings].
+** For backup-to-object policies, set the Datalock and Ransomware protection settings. For details on Datalock and Ransomware protection, refer to link:prev-ontap-policy-object-options.html[Backup-to-object policy settings].
 +
-If your cluster is using ONTAP 9.11.1 or greater, you can choose to protect your backups from deletion and ransomware attacks by configuring _DataLock and Ransomware Resilience_. _DataLock_ protects your backup files from being modified or deleted, and _Ransomware Resilience_ scans your backup files to look for evidence of a ransomware attack in your backup files. 
+If your cluster is using ONTAP 9.11.1 or greater, you can choose to protect your backups from deletion and ransomware attacks by configuring _Datalock and Ransomware protection_. _DataLock_ protects your backup files from being modified or deleted, and _ransomware protection_ scans your backup files to look for evidence of a ransomware attack in your backup files. 
 ** Select *Create*. 
 // In backup to object only (not snapshots and replication) for CVO to AWS, CVO to Azure, onprem to AWS, Azure, S3, and SG - can do Advanced Settings for ransomware scans and datalock. Adv Settings does not apply to Google.)
 

--- a/prev-ontap-policy-object-advanced-settings.adoc
+++ b/prev-ontap-policy-object-advanced-settings.adoc
@@ -158,7 +158,7 @@ When you select the "yearly" backup label for a backup policy for any of your vo
 == Enable or disable ransomware scans
 Ransomware protection scans are enabled by default. The default setting for the scan frequency is for 7 days. The scan occurs only on the latest snapshot. 
 
-For details about DataLock and Ransomware Resilience options, refer to link:prev-ontap-policy-object-options.html[DataLock and Ransomware Resilience options].
+For details about Datalock and Ransomware protection options, refer to link:prev-ontap-policy-object-options.html[Datalock and Ransomware protection options].
 
 You can change that schedule to days or weeks or disable it, saving costs.  
 

--- a/prev-ontap-policy-object-options.adoc
+++ b/prev-ontap-policy-object-options.adoc
@@ -48,7 +48,7 @@ Yearly backups are deleted automatically from the source system after being tran
 
 NetApp Backup and Recovery provides support for DataLock and Ransomware protection for your volume backups. These features enable you to lock your backup files and scan them to detect possible ransomware on the backup files. This is an optional setting that you can define in your backup policies when you want extra protection for your volume backups for a cluster.
 
-Both of these features protect your backup files so that you'll always have a valid backup file to recover data from in case of a ransomware attack attempt on your backups. It's also helpful to meet certain regulatory requirements where backups need to be locked and retained for a certain period of time. When the DataLock and Ransomware Resilience option is enabled, the cloud bucket that is provisioned as a part of NetApp Backup and Recovery activation will have object locking and object versioning enabled.
+Both of these features protect your backup files so that you'll always have a valid backup file to recover data from in case of a ransomware attack attempt on your backups. It's also helpful to meet certain regulatory requirements where backups need to be locked and retained for a certain period of time. When the *Datalock and Ransomware protection* option is enabled, the cloud bucket that is provisioned as a part of NetApp Backup and Recovery activation will have object locking and object versioning enabled.
 
 This feature does not provide protection for your source volumes; only for the backups of those source volumes. Use some of the https://docs.netapp.com/us-en/ontap/anti-ransomware/index.html[anti-ransomware protections provided from ONTAP^] to protect your source volumes.
 
@@ -101,13 +101,13 @@ The DataLock retention setting overrides the policy retention setting from your 
 === Enable DataLock and Ransomware protection
 You can enable DataLock and Ransomware protection when you create a policy. You cannot enable, modify, or disable this after the policy is created. 
 
-. When you create a policy, expand the *DataLock and Ransomware Resilience* section.
+. When you create a policy, expand the *Datalock and Ransomware protection* section.
 
 . Choose one of the following: 
-* *None*: DataLock protection and Ransomware Resilience are disabled.
-* *Unlocked*: DataLock protection and Ransomware Resilience are enabled. Users with specific permissions can overwrite or delete protected backup files during the retention period. 
+* *None*: DataLock protection and ransomware protection are disabled.
+* *Unlocked*: DataLock protection and ransomware protection are enabled. Users with specific permissions can overwrite or delete protected backup files during the retention period. 
 
-* *Locked*: DataLock protection and Ransomware Resilience are enabled. No users can overwrite or delete protected backup files during the retention period. This satisfies full regulatory compliance.
+* *Locked*: DataLock protection and ransomware protection are enabled. No users can overwrite or delete protected backup files during the retention period. This satisfies full regulatory compliance.
 
 
 

--- a/prev-ontap-protect-journey.adoc
+++ b/prev-ontap-protect-journey.adoc
@@ -64,7 +64,7 @@ NOTE: The initial creation of a replicated volume or backup file includes a full
 
 The following table shows a generalized comparison of the three backup methods. While object storage space is typically less expensive than your on-premises disk storage, if you think you might restore data from the cloud frequently, then the egress fees from cloud providers can reduce some of your savings. You'll need to identify how often you need to restore data from the backup files in the cloud.
 
-In addition to this criteria, cloud storage offers additional security options if you use the DataLock and Ransomware Resilience feature, and additional cost savings by selecting archival storage classes for older backup files. link:prev-ontap-policy-object-options.html[Learn more about DataLock and Ransomware protection and archival storage settings].
+In addition to this criteria, cloud storage offers additional security options if you use the *Datalock and Ransomware protection* feature, and additional cost savings by selecting archival storage classes for older backup files. link:prev-ontap-policy-object-options.html[Learn more about DataLock and Ransomware protection and archival storage settings].
 
 [cols=5*,options="header",cols="18,18,22,18,22",width="100%"]
 |===

--- a/prev-ontap-protect-overview.adoc
+++ b/prev-ontap-protect-overview.adoc
@@ -220,7 +220,7 @@ Since NetApp Backup and Recovery preserves the storage efficiencies of the sourc
 
 * If you plan to restore volume data from a backup file that has been moved to archival object storage, then there's an additional per-GiB retrieval fee and per-request fee from the cloud provider.
 
-* If you plan to scan a backup file for ransomware during the process of restoring volume data (if you have enabled DataLock and Ransomware Resilience for your cloud backups), then you'll incur extra egress costs from your cloud provider as well.
+* If you plan to scan a backup file for ransomware during the process of restoring volume data (if you have enabled Datalock and Ransomware protection for your cloud backups), then you'll incur extra egress costs from your cloud provider as well.
 
 *Service charges*
 
@@ -352,7 +352,7 @@ TIP: The retention period for backups of data protection volumes is the same as 
 
 === Backup file protection settings
 
-If your cluster is using ONTAP 9.11.1 or greater, you can protect your backups in object storage from deletion and ransomware attacks. Each backup policy provides a section for _DataLock and Ransomware Resilience_ that can be applied to your backup files for a specific period of time - the _retention period_. 
+If your cluster is using ONTAP 9.11.1 or greater, you can protect your backups in object storage from deletion and ransomware attacks. Each backup policy provides a section for _Datalock and Ransomware protection_ that can be applied to your backup files for a specific period of time - the _retention period_. 
 
 * _DataLock_ protects your backup files from being modified or deleted. 
 * _Ransomware protection_ scans your backup files to look for evidence of a ransomware attack when a backup file is created, and when data from a backup file is being restored.

--- a/prev-ontap-restore-browse.adoc
+++ b/prev-ontap-restore-browse.adoc
@@ -119,7 +119,7 @@ You need the source system name, storage VM, volume name, and backup file date t
 The *Location* column shows whether the backup file (Snapshot) is *Local* (a snapshot on the source system), *Secondary* (a replicated volume on a secondary ONTAP system), or *Object Storage* (a backup file in object storage). Choose the file that you want to restore.
 . Select *Next*.
 +
-Note that if you select a backup file in object storage, and Ransomware Resilience is active for that backup (if you enabled DataLock and Ransomware Resilience in the backup policy), then you are prompted to run an additional ransomware scan on the backup file before restoring the data. We recommend that you scan the backup file for ransomware. (You'll incur extra egress costs from your cloud provider to access the contents of the backup file.)
+Note that if you select a backup file in object storage, and ransomware protection is active for that backup (if you enabled Datalock and Ransomware protection in the backup policy), then you are prompted to run an additional ransomware scan on the backup file before restoring the data. We recommend that you scan the backup file for ransomware. (You'll incur extra egress costs from your cloud provider to access the contents of the backup file.)
 . In the _Select Destination_ page, select the *system* where you want to restore the volume.
 . When restoring a backup file from object storage, if you select an on-premises ONTAP system and you haven't already configured the cluster connection to the object storage, you are prompted for additional information:
 +
@@ -209,7 +209,7 @@ link:prev-reference-aws-archive-storage-tiers.html[Learn more about restoring fr
 link:prev-reference-azure-archive-storage-tiers.html[Learn more about restoring from Azure archival storage].
 link:prev-reference-gcp-archive-storage-tiers.html[Learn more about restoring from Google archival storage]. Backup files in the Google Archive storage tier are restored almost immediately, and require no Restore Priority.
 +
-And if Ransomware Resilience is active for the backup file (if you enabled DataLock and Ransomware Resilience in the backup policy), then you are prompted to run an additional ransomware scan on the backup file before restoring the data. We recommend that you scan the backup file for ransomware. (You'll incur extra egress costs from your cloud provider to access the contents of the backup file.)
+And if ransomware protection is active for the backup file (if you enabled Datalock and Ransomware protection in the backup policy), then you are prompted to run an additional ransomware scan on the backup file before restoring the data. We recommend that you scan the backup file for ransomware. (You'll incur extra egress costs from your cloud provider to access the contents of the backup file.)
 . In the _Select Items_ page, select the folder or file(s) that you want to restore and select *Continue*. To assist you in finding the item:
 * You can select the folder or file name if you see it.
 * You can select the search icon and enter the name of the folder or file to navigate directly to the item.


### PR DESCRIPTION
Fixes issue #81.

This pull request standardizes terminology across documentation by replacing references to "DataLock and Ransomware Resilience" with "Datalock and Ransomware protection" and similar variants. The changes improve consistency and clarity in how ransomware protection features are described in backup and restore workflows, policy creation, and management instructions.

**Terminology updates for backup and restore features:**

* Updated all instances of "DataLock and Ransomware Resilience" to "Datalock and Ransomware protection" across policy creation, backup management, and restore documentation to ensure consistent terminology. [[1]](diffhunk://#diff-6763145eb5bfd5ee8bc11a2d286d99cfa1ad1f5850751cafc8281527167a2e35L349-R349) [[2]](diffhunk://#diff-661f623e34a66f320d9f52521f7c0d90d1c909431a4d2283a74ac243b0e42a0fL358-R358) [[3]](diffhunk://#diff-661f623e34a66f320d9f52521f7c0d90d1c909431a4d2283a74ac243b0e42a0fL371-R371) [[4]](diffhunk://#diff-bb284a364350bbc58798ea3e05ffd22da8949e031ee1a58a0127a38595dfca71L374-R374) [[5]](diffhunk://#diff-bb284a364350bbc58798ea3e05ffd22da8949e031ee1a58a0127a38595dfca71L422-R422) [[6]](diffhunk://#diff-4fed69ce2d84529e5bc1ac575491d44107b7e0b48b3ba636e5674e8388aea87bL69-R69) [[7]](diffhunk://#diff-4fed69ce2d84529e5bc1ac575491d44107b7e0b48b3ba636e5674e8388aea87bL107-R107) [[8]](diffhunk://#diff-4fed69ce2d84529e5bc1ac575491d44107b7e0b48b3ba636e5674e8388aea87bL117-R117) [[9]](diffhunk://#diff-4fed69ce2d84529e5bc1ac575491d44107b7e0b48b3ba636e5674e8388aea87bL147-R147) [[10]](diffhunk://#diff-4fed69ce2d84529e5bc1ac575491d44107b7e0b48b3ba636e5674e8388aea87bL237-R237) [[11]](diffhunk://#diff-4fed69ce2d84529e5bc1ac575491d44107b7e0b48b3ba636e5674e8388aea87bL272-R272) [[12]](diffhunk://#diff-d257d99ab0c5e04ec0fee85042e1a92fa7444187af371ed97d49cd5ccb30859bL399-R399)

**Restore process and scan language improvements:**

* Clarified language in restore instructions to use "ransomware protection" and "Datalock" consistently, and updated scan-related descriptions to match new terminology. [[1]](diffhunk://#diff-a22f2245545f2681485c81fbd080cbf0b5aeecbbcd7777845aaa8ed61c7eb4c2L35-R35) [[2]](diffhunk://#diff-99337d9c77e9c6cb740e56ddcd73d5c41f544a2f35e2cb16df1b35bafc535b8dL41-R41) [[3]](diffhunk://#diff-f487d9372a3802d889155c255383f4a254091ece86f17b98c4f05b4665b779b4L36-R36) [[4]](diffhunk://#diff-fb772ab165382444af76fd527701f8a736b9414e789088dc1352d3ceaa580ab8L35-R35) [[5]](diffhunk://#diff-00ef5c9d720a80d7ccaa569246e150305e4c69d0f5dd2c03b81cfa0923c95963L39-R39) [[6]](diffhunk://#diff-8afdd6caed5448dc53e25a747565345080b5cbec59ee4e4302382d67a0f1ad4eL130-R130) [[7]](diffhunk://#diff-4fed69ce2d84529e5bc1ac575491d44107b7e0b48b3ba636e5674e8388aea87bL160-R160)

These changes enhance documentation clarity and ensure users encounter consistent feature names throughout the product guides. 