### PR TITLE
Hotfix: Fix upgrade version for Trident Protect.

### DIFF
--- a/br-use-manage-kubernetes-clusters.adoc
+++ b/br-use-manage-kubernetes-clusters.adoc
@@ -43,7 +43,7 @@ To stop protecting a Kubernetes cluster, disable protection and delete associate
 . Review the information in the confirmation dialog box, and select *Remove*.
 
 == Upgrade Trident Protect
-For Kubernetes clusters running Trident Protect 26.04 or later, you can upgrade Trident Protect directly from NetApp Backup and Recovery. The upgrade option only appears if a newer version is available.
+For Kubernetes clusters running Trident Protect 26.05 or later, you can upgrade Trident Protect directly from NetApp Backup and Recovery. The upgrade option only appears if a newer version is available.
 
 .Steps
 . In NetApp Backup and Recovery, select *Inventory* > *Clusters*.


### PR DESCRIPTION
This pull request updates the documentation for upgrading Trident Protect in Kubernetes clusters. The main change clarifies the minimum supported version for direct upgrades from NetApp Backup and Recovery.

Documentation update:

* Updated the minimum required version for direct Trident Protect upgrades from "26.04 or later" to "26.05 or later" in the upgrade instructions in `br-use-manage-kubernetes-clusters.adoc`.