### PR TITLE
Hotfix for permalink issues.

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -295,8 +295,6 @@ sidebar:
           url: /prev-reference-azure-archive-storage-tiers.html
         - title: Supported Google Cloud archive storage tiers
           url: /prev-reference-gcp-archive-storage-tiers.html
-        - title: Restore configuration data in a dark site
-          url: /reference-backup-cbs-db-in-dark-site.html
     - title: Legal notices
       url: /legal-notices.html
 product-family:

--- a/redirect/reference-backup-cbs-db-in-dark-site.adoc
+++ b/redirect/reference-backup-cbs-db-in-dark-site.adoc
@@ -1,4 +1,0 @@
----
-permalink: reference-backup-cbs-db-in-dark-site.html
-redirect: data-services-backup-recovery/reference-backup-cbs-db-in-dark-site.html
----

--- a/redirect/task-backup-vm-data-to-aws.adoc
+++ b/redirect/task-backup-vm-data-to-aws.adoc
@@ -1,4 +1,0 @@
----
-permalink: task-backup-vm-data-to-aws.html
-redirect: data-services-backup-recovery/prev-vmware-backup-aws.html
----

--- a/redirect/task-backup-vm-data-to-azure.adoc
+++ b/redirect/task-backup-vm-data-to-azure.adoc
@@ -1,4 +1,0 @@
----
-permalink: task-backup-vm-data-to-azure.html
-redirect: data-services-backup-recovery/prev-vmware-backup-azure.html
----

--- a/redirect/task-backup-vm-data-to-gcp.adoc
+++ b/redirect/task-backup-vm-data-to-gcp.adoc
@@ -1,4 +1,0 @@
----
-permalink: task-backup-vm-data-to-gcp.html
-redirect: data-services-backup-recovery/prev-vmware-backup-gcp.html
----

--- a/redirect/task-backup-vm-data-to-storagegrid.adoc
+++ b/redirect/task-backup-vm-data-to-storagegrid.adoc
@@ -1,4 +1,0 @@
----
-permalink: task-backup-vm-data-to-storagegrid.html
-redirect: data-services-backup-recovery/prev-vmware-backup-storagegrid.html
----

--- a/redirect/task-manage-vm-data-in-cloud.adoc
+++ b/redirect/task-manage-vm-data-in-cloud.adoc
@@ -1,4 +1,0 @@
----
-permalink: task-manage-vm-data-in-cloud.html
-redirect: data-services-backup-recovery/prev-vmware-manage.html
----

--- a/redirect/task-restore-vm-data.adoc
+++ b/redirect/task-restore-vm-data.adoc
@@ -1,4 +1,0 @@
----
-permalink: task-restore-vm-data.html
-redirect: data-services-backup-recovery/prev-vmware-restore.html
----

--- a/reference-backup-cbs-db-in-dark-site.adoc
+++ b/reference-backup-cbs-db-in-dark-site.adoc
@@ -2,7 +2,7 @@
 sidebar: sidebar
 permalink: reference-backup-cbs-db-in-dark-site.html
 keywords: backup database, recover database, dark site, private mode, restore database, backup and recovery, Console agent
-summary: When using NetApp Backup and Recovery in a site with no internet access, known as "private mode", the NetApp Backup and Recovery configuration data is backed up to the StorageGRID or ONTAP S3 bucket where your backups are being stored. If you have an issue with the Console agent host system in the future, you can deploy a new Console agent and restore the critical NetApp Backup and Recovery data.
+summary: In private mode (no internet access), NetApp Backup and Recovery stores its configuration data in the same StorageGRID or ONTAP S3 bucket used for your backups. If the Console agent host system fails, you can deploy a new Console agent and restore this data.
 ---
 
 = Restore NetApp Backup and Recovery configuration data in a dark site
@@ -13,7 +13,7 @@ summary: When using NetApp Backup and Recovery in a site with no internet access
 :imagesdir: ./media/
 
 [.lead]
-When using NetApp Backup and Recovery in a site with no internet access, known as _private mode_, the NetApp Backup and Recovery configuration data is backed up to the StorageGRID or ONTAP S3 bucket where your backups are being stored. If you have an issue with the Console agent host system, you can deploy a new Console agent and restore the critical NetApp Backup and Recovery data. 
+In _private mode_ (no internet access), NetApp Backup and Recovery stores its configuration data in the same StorageGRID or ONTAP S3 bucket used for your backups. If the Console agent host system fails, you can deploy a new Console agent and restore this data.
 
 You can also follow these steps to replace the Console agent and restore configuration data that was stored on it when using Backup and Recovery in _standard mode_ on-premises when no cloud accounts are involved (for example, when using NetApp StorageGrid as the backup destination).
 


### PR DESCRIPTION
This pull request primarily updates documentation related to restoring NetApp Backup and Recovery configuration data in dark site (private mode) environments. The most important changes include improving the clarity of the documentation, removing a sidebar entry, and cleaning up unused redirect files.

Documentation improvements:

* Rewrote the summary and lead paragraph in `reference-backup-cbs-db-in-dark-site.adoc` for better clarity and conciseness, focusing on how configuration data is stored and restored in private mode. [[1]](diffhunk://#diff-4d1f1fa6f63bab24baabfe55fed4a369046426ebed49803fc47f02dc8748f021L5-R5) [[2]](diffhunk://#diff-4d1f1fa6f63bab24baabfe55fed4a369046426ebed49803fc47f02dc8748f021L16-R16)

Navigation and redirects:

* Removed the "Restore configuration data in a dark site" entry from the sidebar in `project.yml` to streamline navigation.
* Deleted unused redirect files related to backup and restore tasks for various cloud providers and dark site documentation, including `redirect/reference-backup-cbs-db-in-dark-site.adoc`, `redirect/task-backup-vm-data-to-aws.adoc`, `redirect/task-backup-vm-data-to-azure.adoc`, `redirect/task-backup-vm-data-to-gcp.adoc`, `redirect/task-backup-vm-data-to-storagegrid.adoc`, `redirect/task-manage-vm-data-in-cloud.adoc`, and `redirect/task-restore-vm-data.adoc`. [[1]](diffhunk://#diff-b0de051ca22ed2a1384ab2b5bd6b86720c17e8b92a7eb0a0d8cc6589695971f6L1-L4) [[2]](diffhunk://#diff-b0326cd5041ec2b015f161d4872a90bee1fde0632fda4d384649a05a4006a870L1-L4) [[3]](diffhunk://#diff-dd45a9fcc56f3c581f4126e0c4f8b5d744492bf807ec4031cb8b4b96abeb2151L1-L4) [[4]](diffhunk://#diff-16ce1bf27b007069080dbd5df1b6315050cc3118c7481f2c417a4de2fa10afcdL1-L4) [[5]](diffhunk://#diff-35c142c4755d7225d876860bcd7ed7dc0900ed89e4943a1179b5e1a5d94a9bc3L1-L4) [[6]](diffhunk://#diff-a6cc27434da119c68daec1f92dc6aff13ba65f66b287af568d8ed0a3ae6fdf20L1-L4) [[7]](diffhunk://#diff-7fdb7b78b4f6a4f0d28cd3b344399fe02bd2aacab18f1ce851c9ee0a47d87d9aL1-L4)