### PR TITLE
Hotfix: Kubernetes release notes updates for May 5 and May 11.

### DIFF
--- a/_whatsnew/2026-05-05.adoc
+++ b/_whatsnew/2026-05-05.adoc
@@ -1,10 +1,10 @@
 === Kubernetes workloads enhancements
 In this release, Kubernetes workloads introduces the following enhancements:
 
-* *Trident Protect 26.0.5*: This release includes Trident Protect 26.0.5.
+* *Trident Protect 26.05*: This release includes Trident Protect 26.05.
+* *Upgrade Trident Protect from Backup and Recovery*: If your Kubernetes cluster is running Trident Protect 26.05 or newer, you can now upgrade Trident Protect directly from Backup and Recovery.
 * *Native support for protecting VMs*: You can now create VM-based applications, enabling you to protect virtual machines the same way you protect any other application.
 * *Resource transformations*: You can now use resource transformations and resource transformation templates to add, remove, and modify resource attributes during the restore process.
-* *Upgrade Trident Protect from Backup and Recovery*: You can now upgrade Trident Protect for a Kubernetes cluster directly from Backup and Recovery.
 * *View protected resources*: You can now view the resources included in each recovery point for an application, and download a detailed JSON report. This gives you full visibility into your recovery points and simplifies audit compliance.
 
 For details about protecting Kubernetes workloads, refer to https://docs.netapp.com/us-en/data-services-backup-recovery/br-use-kubernetes-protect-overview.html[Protect Kubernetes workloads overview].

--- a/_whatsnew/2026-05-05.adoc
+++ b/_whatsnew/2026-05-05.adoc
@@ -1,6 +1,7 @@
 === Kubernetes workloads enhancements
 In this release, Kubernetes workloads introduces the following enhancements:
 
+* *Trident Protect 26.0.5*: This release includes Trident Protect 26.0.5.
 * *Native support for protecting VMs*: You can now create VM-based applications, enabling you to protect virtual machines the same way you protect any other application.
 * *Resource transformations*: You can now use resource transformations and resource transformation templates to add, remove, and modify resource attributes during the restore process.
 * *Upgrade Trident Protect from Backup and Recovery*: You can now upgrade Trident Protect for a Kubernetes cluster directly from Backup and Recovery.

--- a/_whatsnew/2026-05-11.adoc
+++ b/_whatsnew/2026-05-11.adoc
@@ -29,3 +29,11 @@ In this release, VMware workloads introduces the following enhancements:
 * *Clone support*: You can now create clones of virtual machine snapshots from primary and secondary storage.
 
 For details about protecting VMware workloads, refer to https://docs.netapp.com/us-en/data-services-backup-recovery/br-use-vmware-protect-overview.html[Protect VMware workloads overview].
+
+=== Kubernetes workloads enhancements
+In this release, Kubernetes workloads introduces the following enhancements:
+
+* *Trident Protect 26.0.5.1*: This release includes Trident Protect 26.0.5.1.
+* *In-place restore for VM-based apps*: You can now restore VM-based applications to the original namespace and original cluster.
+
+For details about protecting Kubernetes workloads, refer to https://docs.netapp.com/us-en/data-services-backup-recovery/br-use-kubernetes-protect-overview.html[Protect Kubernetes workloads overview].

--- a/_whatsnew/2026-05-11.adoc
+++ b/_whatsnew/2026-05-11.adoc
@@ -33,7 +33,7 @@ For details about protecting VMware workloads, refer to https://docs.netapp.com/
 === Kubernetes workloads enhancements
 In this release, Kubernetes workloads introduces the following enhancements:
 
-* *Trident Protect 26.0.5.1*: This release includes Trident Protect 26.0.5.1.
+* *Trident Protect 26.05.1*: This release includes Trident Protect 26.05.1.
 * *In-place restore for VM-based apps*: You can now restore VM-based applications to the original namespace and original cluster.
 
 For details about protecting Kubernetes workloads, refer to https://docs.netapp.com/us-en/data-services-backup-recovery/br-use-kubernetes-protect-overview.html[Protect Kubernetes workloads overview].

--- a/br-limitations-kubernetes.adoc
+++ b/br-limitations-kubernetes.adoc
@@ -26,7 +26,3 @@ When you change the associated protection policy for an application to use a dif
 When you create a 3-2-1 protection policy where no object storage backups occur at the same time as replication to secondary storage, the protection policy hangs when protecting the application.
 
 *Workaround*: Remove and re-add the application and protect it with a different protection policy.
-
-== In-place restores of VM-based apps from local snapshots are not supported
-
-In-place restore (restoring to the original namespace and original cluster) of VM-based apps from local snapshots is not currently supported.

--- a/br-use-restore-kubernetes-applications.adoc
+++ b/br-use-restore-kubernetes-applications.adoc
@@ -52,9 +52,6 @@ The Restore data wizard begins, and the _General settings_ page appears.
 . Choose the source location to restore from.
 . Choose the destination cluster from the *Cluster* list.
 . Choose to restore to the original namespaces or new namespaces.
-+
-NOTE: In-place restore (restoring to the original namespace and original cluster) of VM-based apps from local snapshots is not currently supported.
-
 . If you chose to restore to new namespaces, enter the destination namespace or namespaces to use.
 . Select *Next*.
 +


### PR DESCRIPTION
This pull request updates the documentation to reflect new Kubernetes workloads enhancements, specifically around Trident Protect and in-place restores for VM-based applications. It also removes outdated limitations and notes to keep the documentation accurate and aligned with recent product improvements.

**Kubernetes workloads enhancements:**

* Added documentation for the release of Trident Protect 26.05 and 26.05.1, including the ability to upgrade Trident Protect directly from Backup and Recovery for clusters running 26.05 or newer. [[1]](diffhunk://#diff-fe1d7d7689e7f162ce2afb3f07a8daebf38a3a8b6bfde77c1f7a8b355a3c6871R4-L6) [[2]](diffhunk://#diff-18ccc5c9ecdb5a003b97964301fd93dd10824b4f194bcbe71af0d3f9d4eb64f7R32-R39)
* Documented support for in-place restore of VM-based applications, allowing restores to the original namespace and cluster.

**Documentation cleanup and accuracy:**

* Removed the limitation and related note that in-place restore for VM-based apps from local snapshots is not supported, reflecting the new support for this feature. [[1]](diffhunk://#diff-f8850c2ea4b06215013d7de66ee4c6373d8588860ccb32753c28355601ac735fL29-L32) [[2]](diffhunk://#diff-bc1a4b419901cc9f43063e3fba86ebc10b313e1aa4b3b20b84ccbb16442d6690L55-L57)