### PR TITLE
Hotfix: Remove outdated UI switch notes.

### DIFF
--- a/br-use-hyperv-protect-overview.adoc
+++ b/br-use-hyperv-protect-overview.adoc
@@ -27,8 +27,6 @@ Use NetApp Backup and Recovery to implement a 3-2-1 protection strategy, where y
 
 When you add Hyper-V hosts and discover resources, NetApp Backup and Recovery installs the NetApp Hyper-V plug-in and the NetApp SnapCenter Windows FileSystem plug-in on the Hyper-V host to help with managing and protecting virtual machines.
 
-NOTE: To switch to and from NetApp Backup and Recovery UI versions, refer to link:br-start-switch-ui.html[Switch to the previous NetApp Backup and Recovery UI].
-
 You can use NetApp Backup and Recovery to perform the following tasks related to Hyper-V workloads:
 
 * link:br-start-discover-hyperv.html[Discover Hyper-V workloads]

--- a/br-use-kvm-protect-overview.adoc
+++ b/br-use-kvm-protect-overview.adoc
@@ -27,8 +27,6 @@ Use NetApp Backup and Recovery to implement a 3-2-1 protection strategy, where y
 * Using different types of media helps you recover if one type fails.
 * You can quickly restore from the onsite copy, and use the offsite copies if the onsite copy is compromised.
 
-NOTE: To switch to and from NetApp Backup and Recovery UI versions, refer to link:br-start-switch-ui.html[Switch to the previous NetApp Backup and Recovery UI].
-
 You can use NetApp Backup and Recovery to perform the following tasks related to KVM workloads:
 
 * link:br-start-discover-kvm.html[Discover KVM workloads]

--- a/br-use-oracle-protect-overview.adoc
+++ b/br-use-oracle-protect-overview.adoc
@@ -23,8 +23,6 @@ Use NetApp Backup and Recovery to implement a 3-2-1 protection strategy, where y
 * Using different types of media helps you recover if one type fails.
 * You can quickly restore from the onsite copy, and use the offsite copies if the onsite copy is compromised.
 
-NOTE: To switch to and from NetApp Backup and Recovery UI versions, refer to link:br-start-switch-ui.html[Switch to the previous NetApp Backup and Recovery UI].
-
 You can use NetApp Backup and Recovery to perform the following tasks related to Oracle Database workloads:
 
 * link:br-start-discover-oracle.html[Discover Oracle Database workloads]

--- a/br-use-vmware-protect-overview.adoc
+++ b/br-use-vmware-protect-overview.adoc
@@ -28,8 +28,6 @@ Use NetApp Backup and Recovery to implement a 3-2-1 strategy, where you have 3 c
 * Using different types of media helps you recover if one type fails.
 * You can quickly restore from the onsite copy, and use the offsite copies if the onsite copy is compromised.
 
-NOTE: To switch to and from NetApp Backup and Recovery UI versions, refer to link:br-start-switch-ui.html[Switch to the previous NetApp Backup and Recovery UI].
-
 You can use NetApp Backup and Recovery to perform the following tasks related to VMware workloads:
 
 * link:br-use-vmware-discovery.html[Discover VMware workloads]

--- a/prev-reference-aws-archive-storage-tiers.adoc
+++ b/prev-reference-aws-archive-storage-tiers.adoc
@@ -15,11 +15,6 @@ summary: NetApp Backup and Recovery supports two S3 archival storage classes and
 [.lead]
 NetApp Backup and Recovery supports two S3 archival storage classes and most regions.
 
-
-====
-NOTE: To switch to and from NetApp Backup and Recovery UI versions, refer to link:br-start-switch-ui.html[Switch to the previous NetApp Backup and Recovery UI].
-====
-
 == Supported S3 archival storage classes for NetApp Backup and Recovery
 
 When backup files are initially created they're stored in S3 _Standard_ storage. This tier is optimized for storing data that's infrequently accessed; but that also allows you to access it immediately. After 30 days the backups transition to the S3 _Standard-Infrequent Access_ storage class to save on costs.

--- a/prev-reference-azure-archive-storage-tiers.adoc
+++ b/prev-reference-azure-archive-storage-tiers.adoc
@@ -15,10 +15,6 @@ summary: NetApp Backup and Recovery supports one Azure archival access tier and 
 [.lead]
 NetApp Backup and Recovery supports one Azure archival access tier and most regions.
 
-====
-NOTE: To switch to and from NetApp Backup and Recovery UI versions, refer to link:br-start-switch-ui.html[Switch to the previous NetApp Backup and Recovery UI].
-====
-
 == Supported Azure Blob access tiers for NetApp Backup and Recovery
 
 When backup files are initially created they're stored in the _Cool_ access tier. This tier is optimized for storing data that's infrequently accessed; but when needed, can be accessed immediately.

--- a/prev-reference-gcp-archive-storage-tiers.adoc
+++ b/prev-reference-gcp-archive-storage-tiers.adoc
@@ -15,13 +15,6 @@ summary: NetApp Backup and Recovery supports one Google archival storage class a
 [.lead]
 NetApp Backup and Recovery supports one Google archival storage class and most regions.
 
-
-====
-NOTE: To switch to and from NetApp Backup and Recovery UI versions, refer to link:br-start-switch-ui.html[Switch to the previous NetApp Backup and Recovery UI].
-====
-
-
-
 == Supported Google archival storage classes for NetApp Backup and Recovery
 
 When backup files are initially created they're stored in _Standard_ storage. This tier is optimized for storing data that's infrequently accessed; but that also allows you to access it immediately.


### PR DESCRIPTION
This pull request removes a recurring note about switching between NetApp Backup and Recovery UI versions from several documentation files. The change streamlines the documentation by eliminating redundant information and improving readability.

Documentation cleanup:

* Removed the note about switching between NetApp Backup and Recovery UI versions from the following overview and reference files:
  * `br-use-hyperv-protect-overview.adoc`
  * `br-use-kvm-protect-overview.adoc`
  * `br-use-oracle-protect-overview.adoc`
  * `br-use-vmware-protect-overview.adoc`
  * `prev-reference-aws-archive-storage-tiers.adoc`
  * `prev-reference-azure-archive-storage-tiers.adoc`
  * `prev-reference-gcp-archive-storage-tiers.adoc`