### PR TITLE
Hotfix: VMware limitations updated.

### DIFF
--- a/br-limitations-vmware.adoc
+++ b/br-limitations-vmware.adoc
@@ -17,11 +17,6 @@ Platforms, devices, or features that do not work or do not work well with this v
 
 The following actions are not supported in VMware workloads in NetApp Backup and Recovery: 
 
-* Mount
-* Unmount
 * vVol support
-* NVMe support
 * Email integration
-* Edit policy
-* Edit protection group
 * Role-based access control (RBAC) support


### PR DESCRIPTION
This pull request updates the documentation for NetApp Backup and Recovery limitations on VMware workloads. The primary change is the removal of several previously listed unsupported actions, likely reflecting updated support or a clarification in the product's capabilities.

**Documentation updates:**

* Removed the following items from the list of unsupported actions: "Mount", "Unmount", "NVMe support", "Edit policy", "Edit protection group", and "Role-based access control (RBAC) support" in `br-limitations-vmware.adoc`.