### PR TITLE
Hotfix: Fixes for links.

### DIFF
--- a/_whatsnew/2026-06-15.adoc
+++ b/_whatsnew/2026-06-15.adoc
@@ -7,18 +7,3 @@ In this release, Kubernetes workloads introduces the following enhancements:
 * *Job monitor improvements*: Job monitoring now provides enhanced visibility into Kubernetes protection jobs. You can view detailed status information about jobs and subjobs, and see the target storage used by each.
 
 For details about protecting Kubernetes workloads, refer to https://docs.netapp.com/us-en/data-services-backup-recovery/br-use-kubernetes-protect-overview.html[Protect Kubernetes workloads overview].
-
-=== Hyper-V workloads enhancements
-In this release, Hyper-V workloads introduces the following enhancements:
-
-* *Restore files and folders to a guest VM improvements*: You can now restore files and folders from a snapshot on primary or secondary storage to a guest Windows VM. This capability is now supported for CIFS and SAN VMs.
-
-For details about protecting Hyper-V workloads, refer to https://docs.netapp.com/us-en/data-services-backup-recovery/br-use-hyperv-protect-overview.html[Protect Hyper-V workloads overview].
-
-=== VMware workloads enhancements
-In this release, VMware workloads introduces the following enhancements:
-
-* *Spanning datastore support for protection groups*: You can now choose the behavior of protection groups when protecting virtual machines whose virtual disks span multiple datastores.
-* *Clone support*: You can now create clones of virtual machine snapshots from primary and secondary storage.
-
-For details about protecting VMware workloads, refer to https://docs.netapp.com/us-en/data-services-backup-recovery/br-use-vmware-protect-overview.html[Protect VMware workloads overview].

--- a/_whatsnew/2026-06-15.adoc
+++ b/_whatsnew/2026-06-15.adoc
@@ -7,3 +7,18 @@ In this release, Kubernetes workloads introduces the following enhancements:
 * *Job monitor improvements*: Job monitoring now provides enhanced visibility into Kubernetes protection jobs. You can view detailed status information about jobs and subjobs, and see the target storage used by each.
 
 For details about protecting Kubernetes workloads, refer to https://docs.netapp.com/us-en/data-services-backup-recovery/br-use-kubernetes-protect-overview.html[Protect Kubernetes workloads overview].
+
+=== Hyper-V workloads enhancements
+In this release, Hyper-V workloads introduces the following enhancements:
+
+* *Restore files and folders to a guest VM improvements*: You can now restore files and folders from a snapshot on primary or secondary storage to a guest Windows VM. This capability is now supported for CIFS and SAN VMs.
+
+For details about protecting Hyper-V workloads, refer to https://docs.netapp.com/us-en/data-services-backup-recovery/br-use-hyperv-protect-overview.html[Protect Hyper-V workloads overview].
+
+=== VMware workloads enhancements
+In this release, VMware workloads introduces the following enhancements:
+
+* *Spanning datastore support for protection groups*: You can now choose the behavior of protection groups when protecting virtual machines whose virtual disks span multiple datastores.
+* *Clone support*: You can now create clones of virtual machine snapshots from primary and secondary storage.
+
+For details about protecting VMware workloads, refer to https://docs.netapp.com/us-en/data-services-backup-recovery/br-use-vmware-protect-overview.html[Protect VMware workloads overview].

--- a/concept-start-prereq.adoc
+++ b/concept-start-prereq.adoc
@@ -259,7 +259,7 @@ a|
 == Requirements for protecting Kubernetes applications
 You need specific requirements to discover Kubernetes resources and protect your Kubernetes applications.
 
-For NetApp Console requirements, refer to <<In NetApp Console>>.
+For NetApp Console requirements, refer to <<Prepare NetApp Console>>.
 
 NOTE: NetApp strongly recommends assigning a static IP address to the Console agent you use for Kubernetes workloads to avoid issues if the agent IP address changes.
 

--- a/prev-ontap-backup-cvo-s3-compatible.adoc
+++ b/prev-ontap-backup-cvo-s3-compatible.adoc
@@ -41,7 +41,7 @@ The following are supported actions when backing up to S3-compatible storage:
 
 * Backup of crash-consistent and app-consistent snapshots from on-premises ONTAP to third-party S3-compatible object stores
 * Core data protection workflows: backup, restore, and backup deletion
-* Validated against S3-compatible providers including Wasabi, MinIO, IBM Object Store, and Apple Object Store
+* Validated against Wasabi, but customers have also successfully used MinIO, IBM Cloud Object Storage, and Apple Object Store
 * NetApp Support accepts and triages all support requests involving third-party S3-compatible object stores
 
 === Unsupported features and configurations

--- a/prev-ontap-backup-cvo-s3-compatible.adoc
+++ b/prev-ontap-backup-cvo-s3-compatible.adoc
@@ -41,7 +41,7 @@ The following are supported actions when backing up to S3-compatible storage:
 
 * Backup of crash-consistent and app-consistent snapshots from on-premises ONTAP to third-party S3-compatible object stores
 * Core data protection workflows: backup, restore, and backup deletion
-* Validated against Wasabi, but customers have also successfully used MinIO, IBM Cloud Object Storage, and Apple Object Store
+* Tested and validated with Wasabi object storage; customers have also reported successful deployments with MinIO, IBM Cloud Object Storage, and Apple Object Store
 * NetApp Support accepts and triages all support requests involving third-party S3-compatible object stores
 
 === Unsupported features and configurations


### PR DESCRIPTION
This pull request makes minor documentation updates to clarify requirements and supported configurations for Kubernetes protection and S3-compatible storage backups.

- Documentation improvements:
  * Updated the reference to NetApp Console requirements to point to the correct section, now labeled "Prepare NetApp Console" (`concept-start-prereq.adoc`).
  * Clarified support for S3-compatible storage by specifying that only Wasabi object storage has been tested and validated, while deployments with MinIO, IBM Cloud Object Storage, and Apple Object Store are based on customer reports (`prev-ontap-backup-cvo-s3-compatible.adoc`).