### PR TITLE
Hotfix: Verda scripts support note.

### DIFF
--- a/br-use-manage-execution-hook-templates.adoc
+++ b/br-use-manage-execution-hook-templates.adoc
@@ -77,4 +77,6 @@ NOTE: If you add a namespace filter to an execution hook that runs after a resto
 == Execution hook examples
 Visit the https://github.com/NetApp/Verda[NetApp Verda GitHub project] to download real execution hooks for popular apps such as Apache Cassandra and Elasticsearch. You can also see examples and get ideas for structuring your own custom execution hooks.
 
+NOTE: NetApp provides these execution hook scripts as-is without official support. Only the execution hooks framework within Trident Protect and Backup and Recovery is officially supported by NetApp.
+
 include::_include/create-exec-hook-template.adoc[]

--- a/br-use-manage-execution-hook-templates.adoc
+++ b/br-use-manage-execution-hook-templates.adoc
@@ -77,6 +77,6 @@ NOTE: If you add a namespace filter to an execution hook that runs after a resto
 == Execution hook examples
 Visit the https://github.com/NetApp/Verda[NetApp Verda GitHub project] to download real execution hooks for popular apps such as Apache Cassandra and Elasticsearch. You can also see examples and get ideas for structuring your own custom execution hooks.
 
-NOTE: NetApp provides these execution hook scripts as-is without official support. Only the execution hooks framework within Trident Protect and Backup and Recovery is officially supported by NetApp.
+NOTE: The scripts in the Verda GitHub repository are provided as-is and are not officially supported by NetApp. Only the execution hooks framework within Trident Protect and Backup and Recovery is officially supported by NetApp.
 
 include::_include/create-exec-hook-template.adoc[]


### PR DESCRIPTION
This pull request adds a clarification to the documentation regarding the support status of scripts in the Verda GitHub repository.

Documentation updates:

* Added a note stating that scripts in the Verda GitHub repository are provided as-is and are not officially supported by NetApp, clarifying that only the execution hooks framework within Trident Protect and Backup and Recovery is officially supported.