### PR TITLE
Hotfix: Various fixes.

### DIFF
--- a/br-limitations.adoc
+++ b/br-limitations.adoc
@@ -69,23 +69,15 @@ NetApp Backup and Recovery does not import on demand backup policies from SnapCe
 
 NetApp Backup and Recovery does not import log-only backup policies from SnapCenter. If a SnapCenter policy includes log-only backups, NetApp Backup and Recovery will not import the resource.
 
-
 *Workaround*: Use a policy in SnapCenter that uses more than just log-only backups. 
-
 
 === Host mapping 
 SnapCenter does not have map storage clusters or SVMs for the resources to hosts, but NetApp Backup and Recovery does. The on-premises ONTAP cluster or SVM will not be mapped to a host in NetApp Backup and Recovery preview versions. Additionally, NetApp Console does not support SVMs. 
 
-
 *Workaround*: Before importing resources from SnapCenter, create a system in NetApp Backup and Recovery for all the on-premises ONTAP storage systems that are registered in on-premises SnapCenter. Then, import the resources for that cluster from SnapCenter into NetApp Backup and Recovery.
-
 
 === Schedules not in 15-minute intervals 
 
 If you have a SnapCenter policy schedule that starts at a certain time and repeats in intervals other than 15-minute intervals, NetApp Backup and Recovery will not import the schedule.
 
-
 *Workaround*: Use SnapCenter to adjust the policy so that it repeats in 15-minute intervals.
-
-== Limited support for virtualization management software
-When you protect KVM workloads, NetApp Backup and Recovery does not support discovery of KVM workloads when virtualization management software such as Apache CloudStack or Red Hat OpenShift Virtualization is in use.

--- a/br-use-policies-kubernetes-create.adoc
+++ b/br-use-policies-kubernetes-create.adoc
@@ -82,12 +82,6 @@ The Policies page appears.
 * *Backup*: Select the frequency of hourly, daily, weekly, monthly, or yearly. 
 * *Backup target*: Select the target system on secondary storage for the backup.
 * *Retention*: Enter the number of snapshots to keep.
-* *Enable snapshot locking*: Select whether you want to enable tamper-proof snapshots. 
-* *Snapshot locking period*: Enter the number of days, months, or years that you want to lock the snapshot.
-* *Transfer to secondary*: 
-** The *ONTAP transfer schedule - Inline* option is selected by default and that indicates that snapshots are transferred to the secondary storage system immediately. You don't need to schedule the backup. 
-** Other options: If you choose a deferred transfer, the transfers are not immediate and you can set a schedule.  
-* *SnapMirror and SnapVault SMAS secondary relationship*: Use SnapMirror and SnapVault SMAS secondary relationships for SQL Server workloads.
 * *Provider*: Select the storage provider that hosts the Kubernetes application resources, and enter the credentials to authenticate with the provider.
 
 . Provide information for the *Object store settings* section (backup to object storage): 

--- a/br-use-protect-kubernetes-applications.adoc
+++ b/br-use-protect-kubernetes-applications.adoc
@@ -35,7 +35,8 @@ Before you can add and protect a Kubernetes application, you need to link:br-sta
 .Steps
 
 . In NetApp Backup and Recovery, select *Inventory*.
-. Choose a Kubernetes instance, and select *View* to view the resources associated with that instance.
+. At the top right of the page, ensure that *Kubernetes* is selected in the list of workloads.
+. Select *View* for the workload line item to view the Kubernetes resources.
 . Select the *Applications* tab.
 . Select *Create application*.
 . Enter a name for the application.

--- a/br-use-protect-kubernetes-applications.adoc
+++ b/br-use-protect-kubernetes-applications.adoc
@@ -70,7 +70,8 @@ The application is created and appears in the list of applications in the *Appli
 .Steps
 
 . In NetApp Backup and Recovery, select *Inventory*.
-. Choose a Kubernetes instance, and select *View* to view the resources associated with that instance.
+. At the top right of the page, ensure that *Kubernetes* is selected in the list of workloads.
+. Select *View* for the workload line item to view the Kubernetes resources.
 . Select the *Applications* tab. 
 . Select *Create application*.
 . Enter a name for the application.

--- a/br-use-vmware-protect-overview.adoc
+++ b/br-use-vmware-protect-overview.adoc
@@ -13,7 +13,7 @@ summary: Protect your VMware workloads with NetApp Backup and Recovery.
 :imagesdir: ./media/
 
 [.lead]
-Protect your VMware VMs and datastores with NetApp Backup and Recovery. NetApp Backup and Recovery provides fast, space-efficient, crash-consistent, and VM-consistent backup and restore operations. You can back up VMware workloads to Amazon Web Services S3 or StorageGRID and restore VMware workloads back to an on-premises VMware host. 
+Protect your VMware VMs and datastores with NetApp Backup and Recovery. NetApp Backup and Recovery provides fast, space-efficient, crash-consistent, and VM-consistent backup and restore operations. You can back up VMware workloads to supported backup targets and restore VMware workloads back to an on-premises VMware host. 
 
 NOTE: This version of NetApp Backup and Recovery supports only VMware vCenter and does not discover vVols or VMs on vVols.  
 

--- a/concept-backup-to-cloud.adoc
+++ b/concept-backup-to-cloud.adoc
@@ -195,7 +195,7 @@ NetApp Backup and Recovery protects the following types of workloads:
 * Amazon Web Services (AWS) S3
 * S3 compatible storage (ONTAP Volumes workloads only)
 * Google Cloud Storage
-* Microsoft Azure Blob (not available for VMware workloads)
+* Microsoft Azure Blob storage
 * StorageGRID
 * ONTAP S3
 

--- a/concept-backup-to-cloud.adoc
+++ b/concept-backup-to-cloud.adoc
@@ -193,10 +193,11 @@ NetApp Backup and Recovery protects the following types of workloads:
 .Supported backup targets
 
 * Amazon Web Services (AWS) S3
+* S3 compatible storage (ONTAP Volumes workloads only)
 * Google Cloud Storage
 * Microsoft Azure Blob (not available for VMware workloads)
 * StorageGRID
-* ONTAP S3 (not available for VMware workloads)
+* ONTAP S3
 
 == How NetApp Backup and Recovery works
 


### PR DESCRIPTION
This pull request updates documentation for NetApp Backup and Recovery, focusing on clarifying supported features, backup targets, and user interface steps. The most important changes include improved descriptions of backup target support, revised instructions for Kubernetes application protection, and the removal of outdated or redundant information.

**Backup Target Support and Feature Clarification:**

* Updated references to supported backup targets for VMware workloads, replacing specific cloud providers (Amazon S3, StorageGRID) with a general "supported backup targets" description in `br-use-vmware-protect-overview.adoc`.
* Clarified and expanded the list of supported backup targets, including S3-compatible storage and ONTAP S3, and updated Azure Blob storage support in `concept-backup-to-cloud.adoc`.

**Kubernetes Application Protection Workflow:**

* Revised instructions for protecting Kubernetes applications to clarify workload selection and resource viewing steps in `br-use-protect-kubernetes-applications.adoc`. [[1]](diffhunk://#diff-45399f388bd42e7b3ab295781925fdf4286d4f3fc726306a8d7d18e7cc99b121L38-R39) [[2]](diffhunk://#diff-45399f388bd42e7b3ab295781925fdf4286d4f3fc726306a8d7d18e7cc99b121L72-R74)

**Policy and Limitation Documentation Clean-up:**

* Removed detailed options for snapshot locking and transfer schedules from the Kubernetes policy creation documentation, simplifying the instructions in `br-use-policies-kubernetes-create.adoc`.
* Cleaned up and removed outdated limitations and workaround sections, including virtualization management software support, from `br-limitations.adoc`.