### PR TITLE
Hotfix: BLUEXPDOC-1323.

### DIFF
--- a/concept-start-prereq.adoc
+++ b/concept-start-prereq.adoc
@@ -59,8 +59,8 @@ To use NetApp Backup and Recovery for ONTAP volume workloads, you need the follo
 
 * ONTAP 9.8 or later is required.
 * ONTAP 9.12.1 or later is required for FlexGroup volume protection. Refer to link:br-reference-limitations.html[Known limitations with NetApp Backup and Recovery for ONTAP volumes] for more information.
+* ONTAP 9.17.1 or later is required for backing up or restoring to S3-compatible object storage.
 * An ONTAP One License must be enabled on the on-premises ONTAP instance.
-* Backing up or restoring to S3-compatible object storage requires ONTAP 9.17.1 or later.
 
 For information about supported features, volume types, backup and restore destinations, and more, refer to link:prev-ontap-protect-overview.html[Protect your ONTAP volume data].
 

--- a/concept-start-prereq.adoc
+++ b/concept-start-prereq.adoc
@@ -58,6 +58,7 @@ To use object storage as backup targets, you need an account with AWS S3, Google
 To use NetApp Backup and Recovery for ONTAP volume workloads, you need the following host system, space, and sizing prerequisites.
 
 * ONTAP 9.8 or later is required.
+* ONTAP 9.12.1 or later is required for FlexGroup volume protection. Refer to link:br-reference-limitations.html[Known limitations with NetApp Backup and Recovery for ONTAP volumes] for more information.
 * An ONTAP One License must be enabled on the on-premises ONTAP instance.
 * Backing up or restoring to S3-compatible object storage requires ONTAP 9.17.1 or later.
 

--- a/prev-ontap-backup-cvo-aws.adoc
+++ b/prev-ontap-backup-cvo-aws.adoc
@@ -251,7 +251,7 @@ You can choose to protect FlexVol or FlexGroup volumes; however, you cannot sele
 [NOTE] 
 ====
 * You can activate a backup only on a single FlexGroup volume at a time. 
-* The volumes you select must have the same SnapLock setting. All volumes must have SnapLock Enterprise enabled or have SnapLock disabled. 
+* When selecting source volumes that you want to protect, you can only select volumes that have matching SnapLock settings. The volumes you select must either all have the SnapLock feature enabled or all have the SnapLock feature disabled. 
 //(Volumes with SnapLock Compliance mode require ONTAP 9.14 or later.)
 ====
 

--- a/prev-ontap-backup-cvo-azure.adoc
+++ b/prev-ontap-backup-cvo-azure.adoc
@@ -252,7 +252,7 @@ You can choose to protect FlexVol or FlexGroup volumes; however, you cannot sele
 [NOTE] 
 ====
 * You can activate a backup only on a single FlexGroup volume at a time. 
-* The volumes you select must have the same SnapLock setting. All volumes must have SnapLock Enterprise enabled or have SnapLock disabled. 
+* When selecting source volumes that you want to protect, you can only select volumes that have matching SnapLock settings. The volumes you select must either all have the SnapLock feature enabled or all have the SnapLock feature disabled. 
 //(Volumes with SnapLock Compliance mode require ONTAP 9.14 or later.)
 ====
 

--- a/prev-ontap-backup-cvo-gcp.adoc
+++ b/prev-ontap-backup-cvo-gcp.adoc
@@ -321,7 +321,7 @@ You can choose to protect FlexVol or FlexGroup volumes; however, you cannot sele
 [NOTE] 
 ====
 * You can activate a backup only on a single FlexGroup volume at a time. 
-* The volumes you select must have the same SnapLock setting. All volumes must have SnapLock Enterprise enabled or have SnapLock disabled. 
+* When selecting source volumes that you want to protect, you can only select volumes that have matching SnapLock settings. The volumes you select must either all have the SnapLock feature enabled or all have the SnapLock feature disabled. 
 //(Volumes with SnapLock Compliance mode require ONTAP 9.14 or later.)
 ====
 

--- a/prev-ontap-backup-cvo-s3-compatible.adoc
+++ b/prev-ontap-backup-cvo-s3-compatible.adoc
@@ -274,7 +274,7 @@ You can choose to protect FlexVol or FlexGroup volumes; however, you cannot sele
 [NOTE] 
 ====
 * You can activate a backup only on a single FlexGroup volume at a time. 
-* The volumes you select must have the same SnapLock setting. All volumes must have SnapLock Enterprise enabled or have SnapLock disabled. 
+* When selecting source volumes that you want to protect, you can only select volumes that have matching SnapLock settings. The volumes you select must either all have the SnapLock feature enabled or all have the SnapLock feature disabled. 
 //(Volumes with SnapLock Compliance mode require ONTAP 9.14 or later.)
 ====
 

--- a/prev-ontap-backup-onprem-aws.adoc
+++ b/prev-ontap-backup-onprem-aws.adoc
@@ -345,7 +345,7 @@ You can choose to protect FlexVol or FlexGroup volumes; however, you cannot sele
 [NOTE] 
 ====
 * You can activate a backup only on a single FlexGroup volume at a time. 
-* The volumes you select must have the same SnapLock setting. All volumes must have SnapLock Enterprise enabled or have SnapLock disabled. 
+* When selecting source volumes that you want to protect, you can only select volumes that have matching SnapLock settings. The volumes you select must either all have the SnapLock feature enabled or all have the SnapLock feature disabled. 
 //(Volumes with SnapLock Compliance mode require ONTAP 9.14 or later.)
 ====
 

--- a/prev-ontap-backup-onprem-azure.adoc
+++ b/prev-ontap-backup-onprem-azure.adoc
@@ -251,7 +251,7 @@ You can choose to protect FlexVol or FlexGroup volumes; however, you cannot sele
 [NOTE] 
 ====
 * You can activate a backup only on a single FlexGroup volume at a time. 
-* The volumes you select must have the same SnapLock setting. All volumes must have SnapLock Enterprise enabled or have SnapLock disabled. 
+* When selecting source volumes that you want to protect, you can only select volumes that have matching SnapLock settings. The volumes you select must either all have the SnapLock feature enabled or all have the SnapLock feature disabled. 
 //(Volumes with SnapLock Compliance mode aren't currently supported require ONTAP 9.14 or later.)
 ====
 

--- a/prev-ontap-backup-onprem-gcp.adoc
+++ b/prev-ontap-backup-onprem-gcp.adoc
@@ -292,7 +292,7 @@ You can choose to protect FlexVol or FlexGroup volumes; however, you cannot sele
 [NOTE] 
 ====
 * You can activate a backup only on a single FlexGroup volume at a time. 
-* The volumes you select must have the same SnapLock setting. All volumes must have SnapLock Enterprise enabled or have SnapLock disabled. 
+* When selecting source volumes that you want to protect, you can only select volumes that have matching SnapLock settings. The volumes you select must either all have the SnapLock feature enabled or all have the SnapLock feature disabled. 
 //(Volumes with SnapLock Compliance mode require ONTAP 9.14 or later.)
 ====
 

--- a/prev-ontap-backup-onprem-ontaps3.adoc
+++ b/prev-ontap-backup-onprem-ontaps3.adoc
@@ -206,7 +206,7 @@ You can choose to protect FlexVol or FlexGroup volumes; however, you cannot sele
 [NOTE] 
 ====
 * You can activate a backup only on a single FlexGroup volume at a time. 
-* The volumes you select must have the same SnapLock setting. All volumes must have SnapLock Enterprise enabled or have SnapLock disabled. 
+* When selecting source volumes that you want to protect, you can only select volumes that have matching SnapLock settings. The volumes you select must either all have the SnapLock feature enabled or all have the SnapLock feature disabled. 
 //(Volumes with SnapLock Compliance mode require ONTAP 9.14 or later.)
 ====
 

--- a/prev-ontap-backup-onprem-storagegrid.adoc
+++ b/prev-ontap-backup-onprem-storagegrid.adoc
@@ -235,7 +235,7 @@ You can choose to protect FlexVol or FlexGroup volumes; however, you cannot sele
 [NOTE] 
 ====
 * You can activate a backup only on a single FlexGroup volume at a time. 
-* The volumes you select must have the same SnapLock setting. All volumes must have SnapLock Enterprise enabled or have SnapLock disabled. 
+* When selecting source volumes that you want to protect, you can only select volumes that have matching SnapLock settings. The volumes you select must either all have the SnapLock feature enabled or all have the SnapLock feature disabled. 
 //(Volumes with SnapLock Compliance mode require ONTAP 9.14 or later.)
 ====
 


### PR DESCRIPTION
This pull request updates the documentation for NetApp Backup and Recovery for ONTAP volumes, focusing on clarifying prerequisites and improving consistency in the description of SnapLock requirements across multiple backup scenarios. The main changes clarify ONTAP version requirements for specific features and standardize the explanation of SnapLock settings when selecting source volumes for protection.

**Prerequisite and Version Requirement Updates:**

* Updated the prerequisites in `concept-start-prereq.adoc` to clarify that ONTAP 9.12.1 or later is required for FlexGroup volume protection, and ONTAP 9.17.1 or later is required for backing up or restoring to S3-compatible object storage. The previous note about S3-compatible object storage was removed and replaced with this clearer requirement.

**SnapLock Setting Clarification (applies to all backup target types):**

* Standardized the language in multiple files to clarify that, when selecting source volumes to protect, all selected volumes must have matching SnapLock settings—either all enabled or all disabled. This replaces the previous, less clear statement about SnapLock Enterprise. The change affects the following files:
  - `prev-ontap-backup-cvo-aws.adoc`
  - `prev-ontap-backup-cvo-azure.adoc`
  - `prev-ontap-backup-cvo-gcp.adoc`
  - `prev-ontap-backup-cvo-s3-compatible.adoc`
  - `prev-ontap-backup-onprem-aws.adoc`
  - `prev-ontap-backup-onprem-azure.adoc`
  - `prev-ontap-backup-onprem-gcp.adoc`
  - `prev-ontap-backup-onprem-ontaps3.adoc`
  - `prev-ontap-backup-onprem-storagegrid.adoc`