### PR TITLE
Hotfix: Fixes for policy creation.

### DIFF
--- a/br-use-policies-hyper-v-create.adoc
+++ b/br-use-policies-hyper-v-create.adoc
@@ -98,7 +98,7 @@ For VMware workloads, this configures the local snapshot on the datastores or VM
 * *Transfer to secondary*: 
 ** The *ONTAP transfer schedule - Inline* option is selected by default and that indicates that snapshots are transferred to the secondary storage system immediately. You don't need to schedule the backup. 
 ** Other options: If you choose a deferred transfer, the transfers are not immediate and you can set a schedule.  
-* *SnapMirror and SnapVault SMAS secondary relationship*: Use SnapMirror and SnapVault SMAS secondary relationships for SQL Server workloads.
+* *Use existing SnapMirror and SyncMirror secondary relationship*: Enable this option to use the existing SnapMirror or SyncMirror relationship to transfer snapshots to the designated destination cluster.
 
 . Provide information for the *Object store settings* section (backup to object storage): 
 +

--- a/br-use-policies-kvm-create.adoc
+++ b/br-use-policies-kvm-create.adoc
@@ -93,7 +93,7 @@ The Policies page appears.
 * *Transfer to secondary*: 
 ** The *ONTAP transfer schedule - Inline* option is selected by default and that indicates that snapshots are transferred to the secondary storage system immediately. You don't need to schedule the backup. 
 ** Other options: If you choose a deferred transfer, the transfers are not immediate and you can set a schedule.  
-* *SnapMirror and SnapVault SMAS secondary relationship*: Use SnapMirror and SnapVault SMAS secondary relationships for SQL Server workloads.
+* *Use existing SnapMirror and SyncMirror secondary relationship*: Enable this option to use the existing SnapMirror or SyncMirror relationship to transfer snapshots to the designated destination cluster.
 
 . Provide information for the *Object store settings* section (backup to object storage): 
 +

--- a/br-use-policies-mssql-create.adoc
+++ b/br-use-policies-mssql-create.adoc
@@ -91,7 +91,7 @@ The Policies page appears.
 * *Snapshot locking period*: Select whether you want to enable tamper-proof snapshots. If enabled, enter the number of days, months, or years that you want to lock the snapshot.
 * *Transfer to secondary*: Choose when to transfer snapshots to secondary storage.
 ** The *ONTAP transfer schedule - Inline* option is selected by default and that indicates that snapshots are transferred to the secondary storage system immediately. You don't need to schedule the backup. 
-** Other options: If you choose a deferred transfer, the transfers are not immediate and you can set a schedule.  
+* *Use existing SnapMirror and SyncMirror secondary relationship*: Enable this option to use the existing SnapMirror or SyncMirror relationship to transfer snapshots to the designated destination cluster.
 
 . Provide information for the *Object store settings* section (backup to object storage): 
 +

--- a/br-use-policies-oracle-create.adoc
+++ b/br-use-policies-oracle-create.adoc
@@ -90,7 +90,7 @@ The Policies page appears.
 * *Transfer to secondary*: 
 ** The *ONTAP transfer schedule - Inline* option is selected by default and that indicates that snapshots are transferred to the secondary storage system immediately. You don't need to schedule the backup. 
 ** Other options: If you choose a deferred transfer, the transfers are not immediate and you can set a schedule.  
-* *SnapMirror and SnapVault SMAS secondary relationship*: Use SnapMirror and SnapVault SMAS secondary relationships for SQL Server workloads.
+* *Use existing SnapMirror and SyncMirror secondary relationship*: Enable this option to use the existing SnapMirror or SyncMirror relationship to transfer snapshots to the designated destination cluster.
 
 . Provide information for the *Object store settings* section (backup to object storage): 
 +

--- a/br-use-policies-vmware-create.adoc
+++ b/br-use-policies-vmware-create.adoc
@@ -106,7 +106,7 @@ For VMware workloads, this configures the local snapshot on the datastores or VM
 * *Transfer to secondary*: 
 ** The *ONTAP transfer schedule - Inline* option is selected by default and that indicates that snapshots are transferred to the secondary storage system immediately. You don't need to schedule the backup. 
 ** Other options: If you choose a deferred transfer, the transfers are not immediate and you can set a schedule.  
-* *SnapMirror and SnapVault SMAS secondary relationship*: Use SnapMirror and SnapVault SMAS secondary relationships for SQL Server workloads.
+* *Use existing SnapMirror and SyncMirror secondary relationship*: Enable this option to use the existing SnapMirror or SyncMirror relationship to transfer snapshots to the designated destination cluster.
 
 . Provide information for the *Object store settings* section (backup to object storage): 
 +

--- a/concept-backup-to-cloud.adoc
+++ b/concept-backup-to-cloud.adoc
@@ -39,10 +39,10 @@ Use NetApp Backup and Recovery to accomplish the following goals:
 ** Use NetApp Backup and Recovery without SnapCenter. 
 ** Refer to link:br-use-mssql-protect-overview.html[Protect Microsoft SQL Server workloads].
 
-* *VMware workloads (with new UI without SnapCenter Plug-in for VMware vSphere)*: 
+* *VMware workloads*: 
 
 ** Protect your VMware VMs and datastores with NetApp Backup and Recovery. 
-** Back up VMware workloads to Amazon Web Services S3 or StorageGRID. 
+** Back up VMware workloads to supported storage providers. 
 ** Restore VMware data from the cloud back to the on-premises vCenter. 
 ** You can restore the VM to the exact same location from where the backup was taken or to an alternate location. 
 ** Use NetApp Backup and Recovery without SnapCenter Plug-in for VMware vSphere. 
@@ -192,12 +192,12 @@ NetApp Backup and Recovery protects the following types of workloads:
 
 .Supported backup targets
 
+* Microsoft Azure Blob storage 
 * Amazon Web Services (AWS) S3
-* S3 compatible storage (ONTAP Volumes workloads only)
-* Google Cloud Storage
-* Microsoft Azure Blob storage
+* Google Cloud Storage (ONTAP Volumes and Kubernetes workloads only)
 * StorageGRID
 * ONTAP S3
+* S3 compatible storage (ONTAP Volumes workloads only)
 
 == How NetApp Backup and Recovery works
 

--- a/reference-backup-cbs-db-in-dark-site.adoc
+++ b/reference-backup-cbs-db-in-dark-site.adoc
@@ -15,7 +15,7 @@ summary: In private mode (no internet access), NetApp Backup and Recovery stores
 [.lead]
 In _private mode_ (no internet access), NetApp Backup and Recovery stores its configuration data in the same StorageGRID or ONTAP S3 bucket used for your backups. If the Console agent host system fails, you can deploy a new Console agent and restore this data.
 
-You can also follow these steps to replace the Console agent and restore configuration data that was stored on it when using Backup and Recovery in _standard mode_ on-premises when no cloud accounts are involved (for example, when using NetApp StorageGrid as the backup destination).
+You can also follow these steps to replace the Console agent and restore configuration data that was stored on it when using Backup and Recovery in _standard mode_ on-premises when no cloud accounts are involved (for example, when using NetApp StorageGRID as the backup destination).
 
 NOTE: This procedure applies only to ONTAP volume data.
 


### PR DESCRIPTION
This pull request updates backup and recovery documentation to clarify supported storage providers and secondary transfer options, and to unify terminology for SnapMirror and SyncMirror relationships across multiple workload types.

**Backup Target and Provider Clarifications:**

* Updated references to VMware workload backup targets to use "supported storage providers" instead of listing only AWS S3 or StorageGRID, reflecting broader support.
* Clarified and reordered the list of supported backup targets, specifying that Google Cloud Storage and S3-compatible storage are supported only for certain workloads.

**Secondary Relationship Option Terminology:**

* Replaced references to "SnapMirror and SnapVault SMAS secondary relationship" with "Use existing SnapMirror and SyncMirror secondary relationship" in policy creation documentation for KVM, VMware, Oracle, Hyper-V, and MSSQL workloads, standardizing the description and expanding applicability beyond SQL Server. [[1]](diffhunk://#diff-fc0fb963609b2913e86e2eca59b7805c837d5ffd07edb1cff819d7720ac3c31dL96-R96) [[2]](diffhunk://#diff-41c9f5eb15ac2516bd59c8f90cc66c9940e5e260b5ab0eaa8bdc79c4f03706feL109-R109) [[3]](diffhunk://#diff-a1a5c166f4f434fcf417f0df2b3b8beb41c3351b14b140f8cbe4e165172e69bfL93-R93) [[4]](diffhunk://#diff-715e8123776c2c86e2fec13c2e3b04fb05bc90e3c5f3a2d4d9e4c61e60be451bL101-R101) [[5]](diffhunk://#diff-ec327bd406a47f46764dc29da453f2dcc5653258c02eaa006140aa1ada8a154cL94-R94)

**Other Minor Changes:**

* No content changes were made to the dark site backup and recovery reference; only whitespace was modified.