### PR TITLE
Hotfix: Grammar.

### DIFF
--- a/br-start-setup.adoc
+++ b/br-start-setup.adoc
@@ -11,7 +11,7 @@ summary: Before you use NetApp Backup and Recovery, perform a few steps to set u
 :imagesdir: ./media/
 
 [.lead]
-Before you use NetApp Backup and Recovery, perform a few steps to set  up backup destinations.  
+Before you use NetApp Backup and Recovery, perform a few steps to set up backup destinations.  
 
 
 Before you begin, review link:concept-start-prereq.html[prerequisites] to ensure that your environment is ready.

--- a/br-use-hyper-v-restore-guest-files-and-folders.adoc
+++ b/br-use-hyper-v-restore-guest-files-and-folders.adoc
@@ -21,7 +21,7 @@ Mount a virtual disk from a snapshot and restore files and folders from it to th
 
 .Before you begin
 
-Before you can restore files and folders, you must create a credential for source VM in NetApp Backup and Recovery. This credential is used used to authenticate with the VM during the restore process.
+Before you can restore files and folders, you must create a credential for source VM in NetApp Backup and Recovery. This credential is used to authenticate with the VM during the restore process.
 
 .About this task
 

--- a/br-use-policies-oracle-create.adoc
+++ b/br-use-policies-oracle-create.adoc
@@ -134,7 +134,7 @@ NOTE: This option is automatically disabled if this policy uses *Local snapshots
 ** *Verification server*: Optionally, select one or more registered Oracle hosts from the list to use as off-host verification servers. If no server is selected, verification runs directly on the source database host. Otherwise, Backup and Recovery mounts the snapshot clone on one of the selected hosts and verifies the backup there, isolating verification I/O from the production database server. A verification server must:
 *** Have the NetApp plug-in installed
 *** Have the Oracle Database binaries installed
-*** Have the same Oracle Database version as the the source database
+*** Have the same Oracle Database version as the source database
 *** Have network access to the storage holding the snapshot (primary or secondary)
 *** Be able to mount the cloned volume and run the Oracle Database DBVERIFY utility.
 * *SnapMirror volume and snapshot format*: Choose from the following options:


### PR DESCRIPTION
This pull request contains minor documentation improvements, specifically correcting duplicate words in two different files.

- Documentation corrections:
  * Fixed a repeated word in the credential creation instructions for restoring files and folders in `br-use-hyper-v-restore-guest-files-and-folders.adoc`.
  * Removed a duplicate word in the requirements for Oracle Database version in `br-use-policies-oracle-create.adoc`.