### PR TITLE
Hotfix: Hyper-V requirements update for SMB and SAN support.

### DIFF
--- a/concept-start-prereq.adoc
+++ b/concept-start-prereq.adoc
@@ -302,8 +302,8 @@ a|
 |Connected storage
 a|
 * ONTAP 9.13.1 or later
-* Amazon FSx for NetApp ONTAP storage systems running version 9.13.1 or later
-* SAN storage (supported for backups and for restoring to the original location from either primary or secondary storage)
+* SMB shares
+* SAN storage connected via iSCSI or Fibre Channel (supported for backups and for restoring to the original location from either primary or secondary storage)
 |===
 
 // snapcenter GH issue #230, 2026-MAR-24
@@ -319,4 +319,4 @@ NOTE: Ensure that you allocate enough disk space on the Hyper-V host for the log
 .NetApp ONTAP configuration requirements
 
 * A primary ONTAP system (ONTAP 9.14.1 or later)
-* For Hyper-V deployments using CIFS shares to store virtual machine data, ensure that the continuous availability share property is enabled on the ONTAP system. Refer to the https://docs.netapp.com/us-en/ontap/smb-hyper-v-sql/configure-shares-continuous-availability-task.html[ONTAP documentation^] for instructions.
+* For Hyper-V deployments using SMB shares to store virtual machine data, ensure that the continuous availability share property is enabled on the ONTAP system. Refer to the https://docs.netapp.com/us-en/ontap/smb-hyper-v-sql/configure-shares-continuous-availability-task.html[ONTAP documentation^] for instructions.

--- a/concept-start-prereq.adoc
+++ b/concept-start-prereq.adoc
@@ -303,7 +303,7 @@ a|
 a|
 * ONTAP 9.13.1 or later
 * SMB shares
-* SAN storage connected via iSCSI or Fibre Channel (supported for backups and for restoring to the original location from either primary or secondary storage)
+* SAN storage connected via iSCSI or Fibre Channel
 |===
 
 // snapcenter GH issue #230, 2026-MAR-24


### PR DESCRIPTION
This pull request updates the storage requirements and terminology in the `concept-start-prereq.adoc` documentation to clarify supported storage types and align with current naming conventions.

**Storage requirements and terminology updates:**

* Clarified the list of supported connected storage by replacing "Amazon FSx for NetApp ONTAP storage systems running version 9.13.1 or later" with "SMB shares" and specifying that SAN storage must be connected via iSCSI or Fibre Channel.
* Updated the ONTAP configuration requirements section to use "SMB shares" instead of "CIFS shares" for Hyper-V deployments, ensuring terminology is consistent and current.