### PR TITLE
Connector -> agent in K8s discovery.

### DIFF
--- a/br-start-discover-kubernetes.adoc
+++ b/br-start-discover-kubernetes.adoc
@@ -34,7 +34,7 @@ When you discover a cluster that is currently protected with Trident Protect, an
 * If you have already discovered Kubernetes workloads, in NetApp Backup and Recovery, select *Inventory* > *Workloads* and then select *Discover resources*.
 
 . Select the *Kubernetes* workload type.
-. Enter a cluster name and choose a connector to use with the cluster.
+. Enter a cluster name and choose a Console agent to use with the cluster.
 . Follow the command line instructions that appear:
 +
 * Create a Trident Protect namespace


### PR DESCRIPTION
This pull request updates the Kubernetes cluster discovery documentation to clarify terminology. The main change is the replacement of "connector" with "Console agent" when selecting the component to use with the cluster.

- Documentation terminology update:
  * In `br-start-discover-kubernetes.adoc`, updated the cluster discovery instructions to refer to selecting a "Console agent" instead of a "connector" when associating with the Kubernetes cluster.