### PR TITLE
Fix for GitHub issue 73.

### DIFF
--- a/prev-ontap-backup-cvo-gcp.adoc
+++ b/prev-ontap-backup-cvo-gcp.adoc
@@ -36,7 +36,8 @@ NetApp Backup and Recovery is supported in all GCP regions.
 GCP Service Account::
 You need to have a service account in your Google Cloud Project that has the custom role. https://docs.netapp.com/us-en/storage-management-cloud-volumes-ontap/task-creating-gcp-service-account.html[Learn how to create a service account^].
 
-NOTE: The Storage Admin role is no longer required for the service account that enables NetApp Backup and Recovery to access Google Cloud Storage buckets. 
+// Removing below note 7/9/2026 - Pradip M from CVO engineering team has confirmed that CVO still needs that role in the GCP service account, regardless of whether B&R needs it.
+//NOTE: The Storage Admin role is no longer required for the service account that enables NetApp Backup and Recovery to access Google Cloud Storage buckets. 
 
 == Verify license requirements
 


### PR DESCRIPTION
Fixes #73

This pull request updates the documentation to clarify service account requirements for NetApp Backup and Recovery on GCP. The main change is the removal of a note about the Storage Admin role, based on confirmation from the engineering team.

Documentation update:

* Removed the note stating that the Storage Admin role is no longer required for the service account, as it has been confirmed that Cloud Volumes ONTAP (CVO) still needs this role in the GCP service account. The note is now commented out with an explanation.