### PR TITLE
Hotfix: Updates for Hyper-V features.

### DIFF
--- a/br-limitations-hyperv.adoc
+++ b/br-limitations-hyperv.adoc
@@ -19,7 +19,7 @@ Platforms, devices, or features that do not work or do not work well with this v
 
 The following actions are not supported in Hyper-V workloads in NetApp Backup and Recovery: 
 
-* Generation 2 VMs that are stored on SAN storage are not supported on Microsoft Windows Server 2025.
+* Protecting generation 2 VMs that are stored on SAN storage is not supported when using Microsoft Windows Server 2025.
 * Create resource groups using VMs from multiple Hyper-V hosts
 * Spanning disks (across multiple CIFS shares)
 * You cannot restore VMs or VM data between systems with different CPU vendors (Intel to AMD or vice versa), regardless of the "Processor compatibility" setting in Hyper-V. This setting only supports compatibility between different generations of the same vendor (e.g., Intel to Intel or AMD to AMD).

--- a/br-limitations-hyperv.adoc
+++ b/br-limitations-hyperv.adoc
@@ -19,6 +19,7 @@ Platforms, devices, or features that do not work or do not work well with this v
 
 The following actions are not supported in Hyper-V workloads in NetApp Backup and Recovery: 
 
+* Generation 2 VMs that are stored on SAN storage are not supported on Microsoft Windows Server 2025.
 * Create resource groups using VMs from multiple Hyper-V hosts
 * Spanning disks (across multiple CIFS shares)
 * You cannot restore VMs or VM data between systems with different CPU vendors (Intel to AMD or vice versa), regardless of the "Processor compatibility" setting in Hyper-V. This setting only supports compatibility between different generations of the same vendor (e.g., Intel to Intel or AMD to AMD).

--- a/br-use-hyper-v-restore-guest-files-and-folders.adoc
+++ b/br-use-hyper-v-restore-guest-files-and-folders.adoc
@@ -34,7 +34,6 @@ Note the following when restoring files and folders:
 [NOTE]
 =====
 * You cannot restore files and folders to Linux guest VMs at this time.
-* Restoring files and folders from backups stored on object storage is not supported.
 * Only one attach or restore operation can run at the same time on a VM. You cannot run parallel attach or restore operations on the same VM.
 * Viewing or browsing reserved partitions might cause an error.
 * During the restore operation, the hidden, system, and encrypted attributes of guest files are not kept in the restored file.

--- a/br-use-hyperv-restore.adoc
+++ b/br-use-hyperv-restore.adoc
@@ -28,7 +28,7 @@ You can restore workloads from different starting locations:
 You can restore data to these points: 
 
 * Restore to the original location (from primary, secondary, and object storage)
-* Restore to an alternate location (from primary and secondary storage)
+* Restore to an alternate location (from primary, secondary, and object storage)
 
 .Restore from object storage considerations
 


### PR DESCRIPTION
This pull request updates documentation to clarify and expand support and limitation details for Hyper-V workloads in NetApp Backup and Recovery. The changes address VM protection limitations, restore operation capabilities, and supported storage types for restore operations.

**Limitations and support updates:**

* Added a limitation stating that protecting generation 2 VMs stored on SAN storage is not supported when using Microsoft Windows Server 2025 (`br-limitations-hyperv.adoc`).

**Restore operation updates:**

* Clarified that restores to alternate locations are now supported from object storage, in addition to primary and secondary storage (`br-use-hyperv-restore.adoc`).
* Removed the note stating that restoring files and folders from backups stored on object storage is not supported, reflecting the expanded support (`br-use-hyper-v-restore-guest-files-and-folders.adoc`).