### PR TITLE
Hotfix: What's New clarity for July 13.

### DIFF
--- a/_whatsnew/2026-07-13.adoc
+++ b/_whatsnew/2026-07-13.adoc
@@ -1,4 +1,4 @@
 === Enhanced multi-bucket support for all workloads
-In this Backup and Recovery release, when using an ONTAP 9.19.1 or later storage system, you can now protect the workloads within a system with up to 100 buckets per system across different cloud providers.
+NetApp Backup and Recovery now supports protecting the workloads within a system with up to 100 buckets across different cloud providers. ONTAP 9.19.1 or later is required to support more than 6 buckets per system.
 
 For details about NetApp Backup and Recovery, refer to https://docs.netapp.com/us-en/data-services-backup-recovery/concept-backup-to-cloud.html[Learn about NetApp Backup and Recovery].

--- a/_whatsnew/2026-07-13.adoc
+++ b/_whatsnew/2026-07-13.adoc
@@ -1,4 +1,4 @@
 === Enhanced multi-bucket support for all workloads
-In this Backup and Recovery release, you can now protect the workloads within a system with up to 100 buckets per system across different cloud providers.
+In this Backup and Recovery release, when using an ONTAP 9.19.1 or later storage system, you can now protect the workloads within a system with up to 100 buckets per system across different cloud providers.
 
 For details about NetApp Backup and Recovery, refer to https://docs.netapp.com/us-en/data-services-backup-recovery/concept-backup-to-cloud.html[Learn about NetApp Backup and Recovery].


### PR DESCRIPTION
This pull request updates the documentation to clarify the requirements for enhanced multi-bucket support in NetApp Backup and Recovery.

Documentation update:

* Updated the description in `_whatsnew/2026-07-13.adoc` to specify that ONTAP 9.19.1 or later is required to support more than 6 buckets per system.